### PR TITLE
Various interface changes and minor performance improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -34,6 +34,7 @@ OptimizationOptimisers = "42dfb2eb-d2b4-4451-abcd-913932933ac1"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+CSDP = "0a46da34-8e4b-519e-b418-48813639ff34"
 
 [targets]
-test = ["SafeTestsets", "Test", "Lux", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "DifferentialEquations"]
+test = ["SafeTestsets", "Test", "Lux", "Optimization", "OptimizationOptimJL", "OptimizationOptimisers", "NLopt", "Random", "NeuralPDE", "DifferentialEquations", "CSDP"]

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -12,16 +12,31 @@ include("minimization_conditions.jl")
 include("decrease_conditions.jl")
 include("decrease_conditions_RoA_aware.jl")
 include("NeuralLyapunovPDESystem.jl")
-include("local_Lyapunov.jl")
+include("numerical_lyapunov_functions.jl")
+include("local_lyapunov.jl")
 include("policy_search.jl")
 
-export NeuralLyapunovPDESystem, NumericalNeuralLyapunovFunctions
-export local_Lyapunov
-export NeuralLyapunovSpecification, NeuralLyapunovStructure, UnstructuredNeuralLyapunov,
-       NonnegativeNeuralLyapunov, PositiveSemiDefiniteStructure,
-       LyapunovMinimizationCondition, StrictlyPositiveDefinite, PositiveSemiDefinite,
-       DontCheckNonnegativity, LyapunovDecreaseCondition, AsymptoticDecrease,
-       ExponentialDecrease, DontCheckDecrease, RoAAwareDecreaseCondition, make_RoA_aware,
-       add_policy_search, get_policy
+# Lyapunov function structures
+export NeuralLyapunovStructure, UnstructuredNeuralLyapunov, NonnegativeNeuralLyapunov,
+       PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
+
+# Minimization conditions
+export LyapunovMinimizationCondition, StrictlyPositiveDefinite, PositiveSemiDefinite,
+       DontCheckNonnegativity
+
+# Decrease conditions
+export LyapunovDecreaseCondition, AsymptoticDecrease, ExponentialDecrease, DontCheckDecrease
+
+# Setting up the PDESystem for NeuralPDE
+export NeuralLyapunovSpecification, NeuralLyapunovPDESystem
+
+# Region of attraction handling
+export RoAAwareDecreaseCondition, make_RoA_aware
+
+# Policy search
+export add_policy_search, get_policy
+
+# Local Lyapunov analysis
+export local_lyapunov
 
 end

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -110,7 +110,7 @@ function NeuralLyapunovPDESystem(
     end
 
     s_syms, p_syms = if dynamics.sys isa ODESystem
-        s_syms = Symbol.(operation.(states(dynamics.sys)))
+        s_syms = Symbol.(operation.(unknowns(dynamics.sys)))
         p_syms = Symbol.(parameters(dynamics.sys))
         (s_syms, p_syms)
     elseif dynamics.sys isa SciMLBase.SymbolCache
@@ -148,7 +148,7 @@ function NeuralLyapunovPDESystem(
 )::PDESystem
     ######################### Check for policy search #########################
     f, x, p, policy_search = if isempty(ModelingToolkit.unbound_inputs(dynamics))
-        (ODEFunction(dynamics), states(dynamics), parameters(dynamics), false)
+        (ODEFunction(dynamics), unknowns(dynamics), parameters(dynamics), false)
     else
         (f, _), x, p = ModelingToolkit.generate_control_function(dynamics; simplify = true)
         (f, x, p, true)

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -57,10 +57,10 @@ struct NeuralLyapunovSpecification
 end
 
 """
-check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)
+    check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)
 
-`true` if `cond` specifies training to meet the Lyapunov minimization condition, `false` if
-`cond` specifies no training to meet this condition.
+Return `true` if `cond` specifies training to meet the Lyapunov minimization condition, and
+`false` if `cond` specifies no training to meet this condition.
 """
 function check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)::Bool
     error("check_nonnegativity not implemented for AbstractLyapunovMinimizationCondition " *
@@ -70,8 +70,8 @@ end
 """
     check_minimal_fixed_point(cond::AbstractLyapunovMinimizationCondition)
 
-`true` if `cond` specifies training for the Lyapunov function to equal zero at the
-fixed point, `false` if `cond` specifies no training to meet this condition.
+Return `true` if `cond` specifies training for the Lyapunov function to equal zero at the
+fixed point, and `false` if `cond` specifies no training to meet this condition.
 """
 function check_minimal_fixed_point(cond::AbstractLyapunovMinimizationCondition)::Bool
     error("check_minimal_fixed_point not implemented for " *
@@ -81,8 +81,8 @@ end
 """
     get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
 
-Returns a function of `V`, `state`, and `fixed_point` that equals zero when the
-Lyapunov minimization condition is met and greater than zero when it's violated.
+Return a function of `V`, `state`, and `fixed_point` that equals zero when the Lyapunov
+minimization condition is met and is greater than zero when it's violated.
 """
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
     error("get_condition not implemented for AbstractLyapunovMinimizationCondition of " *
@@ -92,8 +92,8 @@ end
 """
     check_decrease(cond::AbstractLyapunovDecreaseCondition)
 
-`true` if `cond` specifies training to meet the Lyapunov decrease condition, `false`
-if `cond` specifies no training to meet this condition.
+Return `true` if `cond` specifies training to meet the Lyapunov decrease condition, and
+`false` if `cond` specifies no training to meet this condition.
 """
 function check_decrease(cond::AbstractLyapunovDecreaseCondition)::Bool
     error("check_decrease not implemented for AbstractLyapunovDecreaseCondition of type " *
@@ -103,8 +103,8 @@ end
 """
     get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
 
-Returns a function of `V`, `dVdt`, `state`, and `fixed_point` that is equal to zero
-when the Lyapunov decrease condition is met and greater than zero when it is violated.
+Return a function of `V`, `dVdt`, `state`, and `fixed_point` that is equal to zero
+when the Lyapunov decrease condition is met and is greater than zero when it is violated.
 """
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
     error("get_condition not implemented for AbstractLyapunovDecreaseCondition of type " *

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -1,11 +1,11 @@
 """
-    LyapunovDecreaseCondition(check_decrease, decrease, strength, relu)
+    LyapunovDecreaseCondition(check_decrease, decrease, strength, rectifier)
 
 Specifies the form of the Lyapunov conditions to be used; if `check_decrease`, training will
 enforce `decrease(V, dVdt) ≤ strength(state, fixed_point)`.
 
 The inequality will be approximated by the equation
-    `relu(decrease(V, dVdt) - strength(state, fixed_point)) = 0.0`.
+    `rectifier(decrease(V, dVdt) - strength(state, fixed_point)) = 0.0`.
 
 If the dynamics truly have a fixed point at `fixed_point` and `dVdt` has been defined
 properly in terms of the dynamics, then `dVdt(fixed_point)` will be `0` and there is no need
@@ -27,7 +27,7 @@ struct LyapunovDecreaseCondition <: AbstractLyapunovDecreaseCondition
     check_decrease::Bool
     decrease::Function
     strength::Function
-    relu::Function
+    rectifier::Function
 end
 
 function check_decrease(cond::LyapunovDecreaseCondition)::Bool
@@ -36,7 +36,7 @@ end
 
 function get_decrease_condition(cond::LyapunovDecreaseCondition)
     if cond.check_decrease
-        return (V, dVdt, x, fixed_point) -> cond.relu(
+        return (V, dVdt, x, fixed_point) -> cond.rectifier(
             cond.decrease(V(x), dVdt(x)) - cond.strength(x, fixed_point)
         )
     else
@@ -45,19 +45,19 @@ function get_decrease_condition(cond::LyapunovDecreaseCondition)
 end
 
 """
-    AsymptoticDecrease(; strict, C, relu)
+    AsymptoticDecrease(; strict, C, rectifier)
 
-Constructs a `LyapunovDecreaseCondition` corresponding to asymptotic decrease.
+Construct a `LyapunovDecreaseCondition` corresponding to asymptotic decrease.
 
 If `strict` is `false`, the condition is `dV/dt ≤ 0`, and if `strict` is `true`, the
 condition is `dV/dt ≤ - C | state - fixed_point |^2`.
 
-The inequality is represented by `a ≥ b` <==> `relu(b-a) = 0.0`.
+The inequality is represented by `a ≥ b` <==> `rectifier(b-a) = 0.0`.
 """
 function AsymptoticDecrease(;
         strict::Bool = false,
         C::Real = 1e-6,
-        relu = (t) -> max(0.0, t)
+        rectifier = (t) -> max(zero(t), t)
 )::LyapunovDecreaseCondition
     strength = if strict
         (x, x0) -> -C * (x - x0) ⋅ (x - x0)
@@ -69,25 +69,25 @@ function AsymptoticDecrease(;
         true,
         (V, dVdt) -> dVdt,
         strength,
-        relu
+        rectifier
     )
 end
 
 """
-    ExponentialDecrease(k; strict, C, relu)
+    ExponentialDecrease(k; strict, C, rectifier)
 
-Constructs a `LyapunovDecreaseCondition` corresponding to exponential decrease of rate `k`.
+Construct a `LyapunovDecreaseCondition` corresponding to exponential decrease of rate `k`.
 
 If `strict` is `false`, the condition is `dV/dt ≤ -k * V`, and if `strict` is `true`, the
 condition is `dV/dt ≤ -k * V - C * ||state - fixed_point||^2`.
 
-The inequality is represented by `a ≥ b` <==> `relu(b-a) = 0.0`.
+The inequality is represented by `a ≥ b` <==> `rectifier(b-a) = 0.0`.
 """
 function ExponentialDecrease(
         k::Real;
         strict::Bool = false,
         C::Real = 1e-6,
-        relu = (t) -> max(0.0, t)
+        rectifier = (t) -> max(zero(t), t)
 )::LyapunovDecreaseCondition
     strength = if strict
         (x, x0) -> -C * (x - x0) ⋅ (x - x0)
@@ -99,22 +99,22 @@ function ExponentialDecrease(
         true,
         (V, dVdt) -> dVdt + k * V,
         strength,
-        relu
+        rectifier
     )
 end
 
 """
     DontCheckDecrease()
 
-Constructs a `LyapunovDecreaseCondition` which represents not checking for
+Construct a `LyapunovDecreaseCondition` which represents not checking for
 decrease of the Lyapunov function along system trajectories. This is appropriate
 in cases when the Lyapunov decrease condition has been structurally enforced.
 """
 function DontCheckDecrease()::LyapunovDecreaseCondition
     return LyapunovDecreaseCondition(
         false,
-        (V, dVdt) -> 0.0,
+        (V, dVdt) -> zero(V),
         (state, fixed_point) -> 0.0,
-        (t) -> 0.0
+        (t) -> zero(t)
     )
 end

--- a/src/local_lyapunov.jl
+++ b/src/local_lyapunov.jl
@@ -1,5 +1,5 @@
 """
-    get_local_Lyapunov(dynamics, state_dim; fixed_point, dynamics_jac)
+    get_local_lyapunov(dynamics, state_dim; fixed_point, dynamics_jac)
 
 Use semidefinite programming to derive a quadratic Lyapunov function for the
 linearization of `dynamics` around `fixed_point`.
@@ -10,7 +10,7 @@ calculated using `ForwardDiff`. Other allowable forms are a function which takes
 state and outputs the jacobian of `dynamics` or an `AbstractMatrix` representing the
 Jacobian at `fixed_point`. If `fixed_point` is not specified, it defaults to the origin.
 """
-function local_Lyapunov(dynamics::Function, state_dim, optimizer_factory;
+function local_lyapunov(dynamics::Function, state_dim, optimizer_factory;
         fixed_point = zeros(state_dim), dynamics_jac = nothing,
         p = SciMLBase.NullParameters())
     # Linearize the dynamics

--- a/src/local_lyapunov.jl
+++ b/src/local_lyapunov.jl
@@ -1,36 +1,42 @@
 """
-    get_local_lyapunov(dynamics, state_dim; fixed_point, dynamics_jac)
+    get_local_lyapunov(dynamics, state_dim, optimizer_factory[, jac]; fixed_point, p)
 
-Use semidefinite programming to derive a quadratic Lyapunov function for the
-linearization of `dynamics` around `fixed_point`.
-Return `(V, dV/dt, ∇V)`.
+Use semidefinite programming to derive a quadratic Lyapunov function for the linearization
+of `dynamics` around `fixed_point`. Return `(V, dV/dt)`.
 
-If `isnothing(dynamics_jac)`, the Jacobian of the `dynamics(x, p, t)` with respect to `x` is
-calculated using `ForwardDiff`. Other allowable forms are a function which takes in the
-state and outputs the jacobian of `dynamics` or an `AbstractMatrix` representing the
-Jacobian at `fixed_point`. If `fixed_point` is not specified, it defaults to the origin.
+To solve the semidefinite program, `JuMP.Model` requires an `optimizer_factory` capable of
+semidefinite programming (SDP). See the
+[JuMP documentation](https://jump.dev/JuMP.jl/stable/installation/#Supported-solvers) for
+examples.
+
+If `jac` is not supplied, the Jacobian of the `dynamics(x, p, t)` with respect to `x` is
+calculated using `ForwardDiff`. Otherwise, `jac` is expected to be either a function or an
+`AbstractMatrix`. If `jac isa Function`, it should take in the state and parameters and
+output the Jacobian of `dynamics` with respect to the state `x`. If `jac isa
+AbstractMatrix`, it should be the value of the Jacobian at `fixed_point`.
+
+If `fixed_point` is not specified, it defaults to the origin, i.e., `zeros(state_dim)`.
+Parameters `p` for the dynamics should be supplied when the dynamics depend on them.
 """
-function local_lyapunov(dynamics::Function, state_dim, optimizer_factory;
-        fixed_point = zeros(state_dim), dynamics_jac = nothing,
-        p = SciMLBase.NullParameters())
-    # Linearize the dynamics
-    A = if isnothing(dynamics_jac)
-        ForwardDiff.jacobian(x -> dynamics(x, p, 0.0), fixed_point)
-    elseif dynamics_jac isa AbstractMatrix
-        dynamics_jac
-    elseif dynamics_jac isa Function
-        dynamics_jac(fixed_point)
-    else
-        throw(ErrorException("Unable to calculate Jacobian from dynamics_jac."))
-    end
+function local_lyapunov(dynamics::Function, state_dim, optimizer_factory,
+                        jac::AbstractMatrix{T}; fixed_point = zeros(T, state_dim),
+                        p = SciMLBase.NullParameters()) where T <: Number
 
-    # Use quadratic semidefinite programming to calculate a Lyapunov function
-    # for the linearized system
     model = JuMP.Model(optimizer_factory)
     JuMP.set_silent(model)
+
+    # If jac is a matrix A, then the linearization is ẋ = A (x - x0), where
+    # x is the state and x0 is the fixed point.
+    # A quadratic Lyapunov function is V(x) = (x - x0) ⋅ (P * (x - x0)) for some positive
+    # definite matrix P, where V̇(x) = -(x - x0) ⋅ (Q * (x - x0)) for some positive definite
+    # matrix Q
     JuMP.@variable(model, P[1:state_dim, 1:state_dim], PSD)
     JuMP.@variable(model, Q[1:state_dim, 1:state_dim], PSD)
-    JuMP.@constraint(model, P * A + transpose(A) * P.==-Q)
+
+    # V̇(x) = (x - x0) ⋅ ( (P A + A^T P) * (x - x0)), so we require P A + A^T P = -Q
+    JuMP.@constraint(model, P * jac + transpose(jac) * P.==-Q)
+
+    # Solve the semidefinite program and get the value of P
     JuMP.optimize!(model)
     Psol = JuMP.value.(P)
 
@@ -39,12 +45,40 @@ function local_lyapunov(dynamics::Function, state_dim, optimizer_factory;
     V(states::AbstractMatrix) = mapslices(V, states, dims = [1])
 
     # Numerical gradient of Lyapunov function
-    ∇V(state::AbstractVector) = 2 * ( Psol * (state - fixed_point) )
-    ∇V(states::AbstractMatrix) = mapslices(∇V, states, dims = [1])
+#    ∇V(state::AbstractVector) = 2 * ( Psol * (state - fixed_point) )
+#    ∇V(states::AbstractMatrix) = mapslices(∇V, states, dims = [1])
 
     # Numerical time derivative of Lyapunov function
     V̇(state::AbstractVector) = 2 * dot(dynamics(state, p, 0.0), Psol, state - fixed_point)
     V̇(states::AbstractMatrix) = mapslices(V̇, states, dims = [1])
 
-    return V, V̇, ∇V
+    return V, V̇
+end
+
+function local_lyapunov(dynamics::Function, state_dim, optimizer_factory, jac::Function;
+                        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters())
+
+    A::AbstractMatrix = jac(fixed_point, p)
+    return local_lyapunov(
+        dynamics,
+        state_dim,
+        optimizer_factory,
+        A;
+        fixed_point = fixed_point,
+        p = p
+    )
+end
+
+function local_lyapunov(dynamics::Function, state_dim, optimizer_factory;
+                        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters())
+
+    A::AbstractMatrix = ForwardDiff.jacobian(x -> dynamics(x, p, 0.0), fixed_point)
+    return local_lyapunov(
+        dynamics,
+        state_dim,
+        optimizer_factory,
+        A;
+        fixed_point = fixed_point,
+        p = p
+    )
 end

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -6,7 +6,7 @@ Specifies the form of the Lyapunov conditions to be used.
 If `check_nonnegativity` is `true`, training will attempt to enforce
     `V(state) ≥ strength(state, fixed_point)`.
 The inequality will be approximated by the equation
-    `relu(strength(state, fixed_point) - V(state)) = 0.0`.
+    `rectifier(strength(state, fixed_point) - V(state)) = 0.0`.
 If `check_fixed_point` is `true`, then training will also attempt to enforce
     `V(fixed_point) = 0`.
 
@@ -24,13 +24,13 @@ that must be enforced in training for the Lyapunov function to be uniquely minim
 `fixed_point`. So, in that case, we would use
     `check_nonnegativity = false;  check_fixed_point = true`.
 
-In either case, `relu = (t) -> max(0.0, t)` exactly represents the inequality, but
-approximations of this function are allowed.
+In either case, `rectifier = (t) -> max(0.0, t)` exactly represents the inequality, but
+differentiable approximations of this function may be employed.
 """
 struct LyapunovMinimizationCondition <: AbstractLyapunovMinimizationCondition
     check_nonnegativity::Bool
     strength::Function
-    relu::Function
+    rectifier::Function
     check_fixed_point::Bool
 end
 
@@ -44,31 +44,31 @@ end
 
 function get_minimization_condition(cond::LyapunovMinimizationCondition)
     if cond.check_nonnegativity
-        return (V, x, fixed_point) -> cond.relu(cond.strength(x, fixed_point) - V(x))
+        return (V, x, fixed_point) -> cond.rectifier(cond.strength(x, fixed_point) - V(x))
     else
         return nothing
     end
 end
 
 """
-    StrictlyPositiveDefinite(C; check_fixed_point, relu)
+    StrictlyPositiveDefinite(C; check_fixed_point, rectifier)
 
-Constructs a `LyapunovMinimizationCondition` representing
+Construct a `LyapunovMinimizationCondition` representing
     `V(state) ≥ C * ||state - fixed_point||^2`.
 If `check_fixed_point` is `true`, then training will also attempt to enforce
     `V(fixed_point) = 0`.
 
-The inequality is represented by `a ≥ b` <==> `relu(b-a) = 0.0`.
+The inequality is represented by `a ≥ b` <==> `rectifier(b-a) = 0.0`.
 """
 function StrictlyPositiveDefinite(;
         check_fixed_point = true,
         C::Real = 1e-6,
-        relu = (t) -> max(0.0, t)
+        rectifier = (t) -> max(zero(t), t)
 )::LyapunovMinimizationCondition
     LyapunovMinimizationCondition(
         true,
         (state, fixed_point) -> C * (state - fixed_point) ⋅ (state - fixed_point),
-        relu,
+        rectifier,
         check_fixed_point
     )
 end
@@ -76,21 +76,21 @@ end
 """
     PositiveSemiDefinite(check_fixed_point)
 
-Constructs a `LyapunovMinimizationCondition` representing
+Construct a `LyapunovMinimizationCondition` representing
     `V(state) ≥ 0`.
 If `check_fixed_point` is `true`, then training will also attempt to enforce
     `V(fixed_point) = 0`.
 
-The inequality is represented by `a ≥ b` <==> `relu(b-a) = 0.0`.
+The inequality is represented by `a ≥ b` <==> `rectifier(b-a) = 0.0`.
 """
 function PositiveSemiDefinite(;
         check_fixed_point = true,
-        relu = (t) -> max(0.0, t)
+        rectifier = (t) -> max(zero(t), t)
 )::LyapunovMinimizationCondition
     LyapunovMinimizationCondition(
         true,
         (state, fixed_point) -> 0.0,
-        relu,
+        rectifier,
         check_fixed_point
     )
 end
@@ -98,7 +98,7 @@ end
 """
     DontCheckNonnegativity(check_fixed_point)
 
-Constructs a `LyapunovMinimizationCondition` which represents not checking for nonnegativity
+Construct a `LyapunovMinimizationCondition` which represents not checking for nonnegativity
 of the Lyapunov function. This is appropriate in cases where this condition has been
 structurally enforced.
 
@@ -110,7 +110,7 @@ function DontCheckNonnegativity(; check_fixed_point = false)::LyapunovMinimizati
     LyapunovMinimizationCondition(
         false,
         (state, fixed_point) -> 0.0,
-        (t) -> 0.0,
+        (t) -> zero(t),
         check_fixed_point
     )
 end

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -48,7 +48,7 @@ function get_numerical_lyapunov_function(
     # V is the numerical form of Lyapunov function
     V = let V_structure = structure.V, net = network_func, x0 = fixed_point
         V(state::AbstractVector) = V_structure(net, state, x0)
-        V(state::AbstractMatrix) = mapslices(V, state, dims = [1])
+        V(states::AbstractMatrix) = mapslices(V, states, dims = [1])
     end
 
     if use_V̇_structure
@@ -68,7 +68,7 @@ function get_numerical_lyapunov_function(
 
             # Numerical time derivative of Lyapunov function
             V̇(state::AbstractVector) = V̇_structure(net, _J_net, f, state, params, 0.0, x0)
-            V̇(state::AbstractMatrix) = mapslices(V̇, state, dims = [1])
+            V̇(states::AbstractMatrix) = mapslices(V̇, states, dims = [1])
 
             return _V, V̇
         end
@@ -81,7 +81,7 @@ function get_numerical_lyapunov_function(
                 (δt) -> _V(state + δt * f_call(f, net, state, params, 0.0)),
                 0.0
             )
-            V̇(state::AbstractMatrix) = mapslices(V̇, state, dims = [1])
+            V̇(states::AbstractMatrix) = mapslices(V̇, states, dims = [1])
 
             return _V, V̇
         end
@@ -95,8 +95,8 @@ Return the network as a function of state alone.
 
 # Arguments
 
-- `phi`: the neural network, represented as `phi(state, θ)` if the neural network has a
-        single output, or a `Vector` of the same with one entry per neural network output.
+- `phi`: the neural network, represented as `phi(x, θ)` if the neural network has a single
+        output, or a `Vector` of the same with one entry per neural network output.
 - `θ`: the parameters of the neural network; `θ[:φ1]` should be the parameters of the first
         neural network output (even if there is only one), `θ[:φ2]` the parameters of the
         second (if there are multiple), and so on.
@@ -105,7 +105,7 @@ Return the network as a function of state alone.
 """
 function phi_to_net(phi, θ)
     let _θ = θ, φ = phi
-        return (state) -> φ(state, _θ[:φ1])
+        return (x) -> φ(x, _θ[:φ1])
     end
 end
 

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -1,0 +1,93 @@
+"""
+    get_numerical_lyapunov_function(phi, θ, structure, dynamics, fixed_point;
+                                    <keyword_arguments>)
+
+Combine Lyapunov function structure, dynamics, and neural network weights to generate Julia
+functions representing the Lyapunov function and its time derivative: ``V(x), V̇(x)``.
+
+These functions can operate on a state vector or columnwise on a matrix of state vectors.
+
+# Arguments
+- `phi`, `θ`: `phi` is the neural network with parameters `θ`.
+- `structure`: a [`NeuralLyapunovStructure`](@ref) representing the structure of the neural
+        Lyapunov function.
+- `dynamics`: the system dynamics, as a function to be used in conjunction with
+        `structure.f_call`.
+- `fixed_point`: the equilibrium point being analyzed by the Lyapunov function.
+- `p`: parameters to be passed into `dynamics`; defaults to `SciMLBase.NullParameters()`.
+- `use_V̇_structure`: when `true`, ``V̇(x)`` is calculated using `structure.V̇`; when `false`,
+        ``V̇(x)`` is calculated using `deriv` as ``\\frac{d}{dt} V(x + t f(x))`` at
+        ``t = 0``; defaults to `false`, as it is more efficient in many cases.
+- `deriv`: a function for calculating derivatives; defaults to (and expects same arguments
+        as) `ForwardDiff.derivative`; only used when `use_V̇_structure` is `false`.
+- `jac`: a function for calculating Jacobians; defaults to (and expects same arguments as)
+        `ForwardDiff.jacobian`; only used when `use_V̇_structure` is `true`.
+- `J_net`: the Jacobian of the neural network, specified as a function
+        `J_net(phi, θ, state)`; if `isnothing(J_net)` (as is the default), `J_net` will be
+        calculated using `jac`; only used when `use_V̇_structure` is `true`.
+"""
+function get_numerical_lyapunov_function(
+        phi,
+        θ,
+        structure::NeuralLyapunovStructure,
+        dynamics::Function,
+        fixed_point;
+        p = SciMLBase.NullParameters(),
+        use_V̇_structure = false,
+        deriv = ForwardDiff.derivative,
+        jac = ForwardDiff.jacobian,
+        J_net = nothing
+)::Tuple{Function, Function}
+    # network_func is the numerical form of neural network output
+    output_dim = structure.network_dim
+    network_func = let φ = phi, _θ = θ, dim = output_dim
+        function (x)
+            reduce(
+                vcat,
+                Array(φ[i](x, _θ.depvar[Symbol(:φ, i)])) for i in 1:dim
+            )
+        end
+    end
+
+    # V is the numerical form of Lyapunov function
+    V = let V_structure = structure.V, net = network_func, x0 = fixed_point
+        V(state::AbstractVector) = V_structure(net, state, x0)
+        V(state::AbstractMatrix) = mapslices(V, state, dims = [1])
+    end
+
+    if use_V̇_structure
+        # Make Jacobian of network_func
+        network_jacobian = if isnothing(J_net)
+            let net = network_func, J = jac
+                (x) -> J(net, x)
+            end
+        else
+            let _J_net = J_net, φ = phi, _θ = θ
+                (x) -> _J_net(φ, _θ, x)
+            end
+        end
+
+        let _V = V, V̇_structure = structure.V̇, net = network_func, x0 = fixed_point,
+            f = dynamics, params = p, _J_net = network_jacobian
+
+            # Numerical time derivative of Lyapunov function
+            V̇(state::AbstractVector) = V̇_structure(net, _J_net, f, state, params, 0.0, x0)
+            V̇(state::AbstractMatrix) = mapslices(V̇, state, dims = [1])
+
+            return _V, V̇
+        end
+    else
+        let f_call = structure.f_call, _V = V, net = network_func, f = dynamics, params = p,
+            _deriv = deriv
+
+            # Numerical time derivative of Lyapunov function
+            V̇(state::AbstractVector) = _deriv(
+                (δt) -> _V(state + δt * f_call(f, net, state, params, 0.0)),
+                0.0
+            )
+            V̇(state::AbstractMatrix) = mapslices(V̇, state, dims = [1])
+
+            return _V, V̇
+        end
+    end
+end

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -67,17 +67,14 @@ function get_policy(
         control_dim::Integer;
         control_structure::Function = identity
 )
-    function policy(state::AbstractVector)
-        control_structure(
-            reduce(
-                vcat,
-                Array(phi[i](state, θ.depvar[Symbol(:φ, i)]))
-                    for i in (network_dim - control_dim + 1):network_dim
-            )
-        )
-    end
+    network_func = phi_to_net(phi, θ; idx = (network_dim - control_dim + 1):network_dim)
 
-    policy(state::AbstractMatrix) = mapslices(policy, state, dims = [1])
+    policy(state::AbstractVector) = control_structure(network_func(state))
+    policy(states::AbstractMatrix) = mapslices(
+            control_structure,
+            network_func(states),
+            dims = [1]
+        )
 
     return policy
 end

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -1,12 +1,12 @@
 """
     add_policy_search(lyapunov_structure, new_dims, control_structure)
 
-Adds dependence on the neural network to the dynamics in a `NeuralLyapunovStructure`
+Add dependence on the neural network to the dynamics in a `NeuralLyapunovStructure`.
 
-Adds `new_dims` outputs to the neural network and feeds them through `control_structure` to
-calculatethe contribution of the neural network to the dynamics.
-The existing `lyapunov_structure.network_dim` dimensions are used as in `lyapunov_structure`
-to calculate the Lyapunov function.
+Add `new_dims` outputs to the neural network and feeds them through `control_structure` to
+calculate the contribution of the neural network to the dynamics.
+Use the existing `lyapunov_structure.network_dim` dimensions as in `lyapunov_structure` to
+calculate the Lyapunov function.
 
 `lyapunov_structure` should assume in its `V̇` that the dynamics take a form `f(x, p, t)`.
 The returned `NeuralLyapunovStructure` will assume instead `f(x, u, p, t)`, where `u` is the
@@ -51,7 +51,7 @@ end
 """
     get_policy(phi, θ, network_func, dim; control_structure)
 
-Returns the control policy as a function of the state
+Generate a Julia function representing the control policy as a function of the state
 
 The returned function can operate on a state vector or columnwise on a matrix of state
 vectors.

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -1,7 +1,7 @@
 """
     UnstructuredNeuralLyapunov()
 
-Creates a `NeuralLyapunovStructure` where the Lyapunov function is the neural network
+Create a `NeuralLyapunovStructure` where the Lyapunov function is the neural network
 evaluated at the state. This does not structurally enforce any Lyapunov conditions.
 
 Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
@@ -21,7 +21,7 @@ end
 """
     NonnegativeNeuralLyapunov(network_dim, δ, pos_def; grad_pos_def, grad)
 
-Creates a `NeuralLyapunovStructure` where the Lyapunov function is the L2 norm of the neural
+Create a `NeuralLyapunovStructure` where the Lyapunov function is the L2 norm of the neural
 network output plus a constant δ times a function `pos_def`.
 
 The condition that the Lyapunov function must be minimized uniquely at the fixed point can
@@ -85,7 +85,7 @@ end
 """
     PositiveSemiDefiniteStructure(network_dim; pos_def, non_neg, grad_pos_def, grad_non_neg, grad)
 
-Creates a `NeuralLyapunovStructure` where the Lyapunov function is the product of a positive
+Create a `NeuralLyapunovStructure` where the Lyapunov function is the product of a positive
 (semi-)definite function `pos_def` which does not depend on the network and a nonnegative
 function non_neg which does depend the network.
 

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -103,11 +103,10 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
     res.u,
-    dim_output,
-    structure.V,
+    structure,
     ODEFunction(dynamics),
     zeros(length(bounds));
     p = p

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -109,7 +109,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
-    res.u,
+    res.u.depvar,
     structure,
     ODEFunction(dynamics),
     zeros(length(bounds));

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -18,7 +18,7 @@ defaults = Dict([ζ => 0.5, ω_0 => 1.0])
 Dt = Differential(t)
 DDt = Dt^2
 
-eqs = [DDt(θ) + 2ζ * Dt(θ) + ω_0^2 * sin(θ) ~ 0.0]
+eqs = [DDt(θ) + 2ζ * ω_0 * Dt(θ) + ω_0^2 * sin(θ) ~ 0.0]
 
 @named dynamics = ODESystem(
     eqs,
@@ -71,7 +71,11 @@ structure = PositiveSemiDefiniteStructure(
 minimization_condition = DontCheckNonnegativity(check_fixed_point = false)
 
 # Define Lyapunov decrease condition
-decrease_condition = AsymptoticDecrease(strict = true)
+κ = 20.0
+decrease_condition = AsymptoticDecrease(
+    strict = true,
+    rectifier = (t) -> log(1.0 + exp(κ * t)) / κ
+)
 
 # Construct neural Lyapunov specification
 spec = NeuralLyapunovSpecification(

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -82,7 +82,7 @@ spec = NeuralLyapunovSpecification(
 
 ############################# Construct PDESystem #############################
 
-pde_system, network_func = NeuralLyapunovPDESystem(
+@named pde_system = NeuralLyapunovPDESystem(
     ODEFunction(dynamics),
     lb,
     ub,
@@ -103,10 +103,10 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func, ∇V_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = NumericalNeuralLyapunovFunctions(
     discretization.phi,
     res.u,
-    network_func,
+    dim_output,
     structure.V,
     ODEFunction(dynamics),
     zeros(length(bounds));

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -81,7 +81,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 500)
 ###################### Get numerical numerical functions ######################
 V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
-    res.u,
+    res.u.depvar,
     structure,
     f,
     zeros(2);

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -50,7 +50,7 @@ minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 κ = 20.0
 decrease_condition = AsymptoticDecrease(
     strict = true,
-    relu = (t) -> log(1.0 + exp(κ * t)) / κ
+    rectifier = (t) -> log(1.0 + exp(κ * t)) / κ
 )
 
 # Construct neural Lyapunov specification
@@ -82,14 +82,14 @@ prob = Optimization.remake(prob, u0 = res.u)
 res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
-V_func, V̇_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
     res.u,
-    dim_output,
-    structure.V,
-    ODEFunction(dynamics),
+    structure,
+    f,
     zeros(2);
-    p = p
+    p = p,
+    use_V̇_structure = true
 )
 
 ################################## Simulate ###################################

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -62,7 +62,7 @@ spec = NeuralLyapunovSpecification(
 
 ############################# Construct PDESystem #############################
 
-pde_system, network_func = NeuralLyapunovPDESystem(
+@named pde_system = NeuralLyapunovPDESystem(
     dynamics,
     lb,
     ub,
@@ -82,10 +82,10 @@ prob = Optimization.remake(prob, u0 = res.u)
 res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
-V_func, V̇_func, ∇V_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = NumericalNeuralLyapunovFunctions(
     discretization.phi,
     res.u,
-    network_func,
+    dim_output,
     structure.V,
     ODEFunction(dynamics),
     zeros(2);

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -77,7 +77,7 @@ spec = NeuralLyapunovSpecification(
 
 ############################# Construct PDESystem #############################
 
-pde_system, network_func = NeuralLyapunovPDESystem(
+@named pde_system = NeuralLyapunovPDESystem(
     open_loop_pendulum_dynamics,
     lb,
     ub,
@@ -102,17 +102,16 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func, ∇V_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = NumericalNeuralLyapunovFunctions(
     discretization.phi,
     res.u,
-    network_func,
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
     p = p
 )
 
-u = get_policy(discretization.phi, res.u, network_func, dim_u)
+u = get_policy(discretization.phi, res.u, dim_output, dim_u)
 
 ################################## Simulate ###################################
 

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -104,14 +104,14 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
-    res.u,
+    res.u.depvar,
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
     p = p
 )
 
-u = get_policy(discretization.phi, res.u, dim_output, dim_u)
+u = get_policy(discretization.phi, res.u.depvar, dim_output, dim_u)
 
 ################################## Simulate ###################################
 

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -102,7 +102,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
     res.u,
     structure,

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -16,7 +16,7 @@ function open_loop_pendulum_dynamics(x, u, p, t)
     ζ, ω_0 = p
     τ = u[]
     return [ω
-            -2ζ * ω - ω_0^2 * sin(θ) + τ]
+            -2ζ * ω_0 * ω - ω_0^2 * sin(θ) + τ]
 end
 
 lb = [0.0, -10.0];

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -110,7 +110,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
     res.u,
     structure,

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -112,14 +112,14 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
-    res.u,
+    res.u.depvar,
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
     p = p
 )
 
-u = get_policy(discretization.phi, res.u, dim_output, dim_u)
+u = get_policy(discretization.phi, res.u.depvar, dim_output, dim_u)
 
 ################################## Simulate ###################################
 

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -18,7 +18,7 @@ defaults = Dict([ζ => 0.5, ω_0 => 1.0])
 Dt = Differential(t)
 DDt = Dt^2
 
-eqs = [DDt(θ) + 2ζ * Dt(θ) + ω_0^2 * sin(θ) ~ τ]
+eqs = [DDt(θ) + 2ζ * ω_0 * Dt(θ) + ω_0^2 * sin(θ) ~ τ]
 
 @named driven_pendulum = ODESystem(
     eqs,

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -90,7 +90,7 @@ spec = NeuralLyapunovSpecification(
 
 ############################# Construct PDESystem #############################
 
-pde_system, network_func = NeuralLyapunovPDESystem(
+@named pde_system = NeuralLyapunovPDESystem(
     driven_pendulum,
     bounds,
     spec;
@@ -110,17 +110,16 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
 
-V_func, V̇_func, ∇V_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = NumericalNeuralLyapunovFunctions(
     discretization.phi,
     res.u,
-    network_func,
     structure,
     open_loop_pendulum_dynamics,
     upright_equilibrium;
     p = p
 )
 
-u = get_policy(discretization.phi, res.u, network_func, dim_u)
+u = get_policy(discretization.phi, res.u, dim_output, dim_u)
 
 ################################## Simulate ###################################
 

--- a/test/local_lyapunov.jl
+++ b/test/local_lyapunov.jl
@@ -1,0 +1,40 @@
+using NeuralLyapunov, CSDP, ForwardDiff, Test, LinearAlgebra
+
+################################### ẋ = -x ###################################
+# Set up dynamics with a known Lyapunov function: V(x) = C x ⋅ x
+f1(x, p, t) = -x
+
+# Set up Jacobian
+J1(x, p) = (-1.0*I)(3)
+
+# Find Lyapunov function and rescale for C = 1
+_V1, _V̇1 = local_lyapunov(f1, 3, CSDP.Optimizer, J1)
+V1(x) = _V1(x) ./ _V1([0, 0, 1])
+
+# Test equality
+xs = -1:0.1:1
+states = Iterators.map(collect, Iterators.product(xs, xs, xs))
+errs1 = @. abs(V1(states) - states ⋅ states)
+@test all(errs1 .< 1e-10)
+
+########################## Simple harmonic oscillator #########################
+function f2(state, p, t)
+    ζ, ω_0 = p
+    pos, vel = state
+    vcat(vel, -2ζ * vel - ω_0^2 * pos)
+end
+p2 = [3.2, 5.1]
+
+# Find Lyapunov function and derivative
+V2, V̇2 = local_lyapunov(f2, 2, CSDP.Optimizer; p = p2)
+dV2dt = (state) -> ForwardDiff.derivative((δt) -> V2(state + δt * f2(state, p2, 0.0)), 0.0)
+
+# Test V̇2 = d/dt V2
+xs = -1:0.03:1
+states = Iterators.map(collect, Iterators.product(xs, xs))
+errs2 = @. abs(dV2dt(states) - V̇2(states))
+@test all(errs2 .< 1e-10)
+
+# Test V̇2 ≺ 0
+@test all( @. V̇2(states) < 0)
+@test V̇2(zeros(2)) == 0.0

--- a/test/local_lyapunov.jl
+++ b/test/local_lyapunov.jl
@@ -21,12 +21,12 @@ errs1 = @. abs(V1(states1) - states1 ⋅ states1)
 function f2(state::AbstractVector, p, t)
     ζ, ω_0 = p
     pos, vel = state
-    vcat(vel, -2ζ * vel - ω_0^2 * pos)
+    vcat(vel, -2ζ * ω_0 * vel - ω_0^2 * pos)
 end
 function f2(states::AbstractMatrix, p, t)
     ζ, ω_0 = p
     pos, vel = states[1,:], states[2,:]
-    vcat(transpose(vel), transpose(-2ζ * vel - ω_0^2 * pos))
+    vcat(transpose(vel), transpose(-2ζ * ω_0 * vel - ω_0^2 * pos))
 end
 p2 = [3.2, 5.1]
 

--- a/test/local_lyapunov.jl
+++ b/test/local_lyapunov.jl
@@ -12,16 +12,21 @@ _V1, _V̇1 = local_lyapunov(f1, 3, CSDP.Optimizer, J1)
 V1(x) = _V1(x) ./ _V1([0, 0, 1])
 
 # Test equality
-xs = -1:0.1:1
-states = Iterators.map(collect, Iterators.product(xs, xs, xs))
-errs1 = @. abs(V1(states) - states ⋅ states)
+xs1 = -1:0.1:1
+states1 = Iterators.map(collect, Iterators.product(xs1, xs1, xs1))
+errs1 = @. abs(V1(states1) - states1 ⋅ states1)
 @test all(errs1 .< 1e-10)
 
 ########################## Simple harmonic oscillator #########################
-function f2(state, p, t)
+function f2(state::AbstractVector, p, t)
     ζ, ω_0 = p
     pos, vel = state
     vcat(vel, -2ζ * vel - ω_0^2 * pos)
+end
+function f2(states::AbstractMatrix, p, t)
+    ζ, ω_0 = p
+    pos, vel = states[1,:], states[2,:]
+    vcat(transpose(vel), transpose(-2ζ * vel - ω_0^2 * pos))
 end
 p2 = [3.2, 5.1]
 
@@ -30,11 +35,11 @@ V2, V̇2 = local_lyapunov(f2, 2, CSDP.Optimizer; p = p2)
 dV2dt = (state) -> ForwardDiff.derivative((δt) -> V2(state + δt * f2(state, p2, 0.0)), 0.0)
 
 # Test V̇2 = d/dt V2
-xs = -1:0.03:1
-states = Iterators.map(collect, Iterators.product(xs, xs))
-errs2 = @. abs(dV2dt(states) - V̇2(states))
+xs2 = -1:0.03:1
+states2 = hcat(Iterators.map(collect, Iterators.product(xs2, xs2))...)
+errs2 = abs.( V̇2(states2) .- dV2dt(states2))
 @test all(errs2 .< 1e-10)
 
 # Test V̇2 ≺ 0
-@test all( @. V̇2(states) < 0)
+@test all( V̇2(states2) .< 0)
 @test V̇2(zeros(2)) == 0.0

--- a/test/roa_estimation.jl
+++ b/test/roa_estimation.jl
@@ -47,7 +47,7 @@ spec = NeuralLyapunovSpecification(
 
 ############################# Construct PDESystem #############################
 
-pde_system, network_func = NeuralLyapunovPDESystem(
+@named pde_system = NeuralLyapunovPDESystem(
     f,
     lb,
     ub,
@@ -66,10 +66,9 @@ prob = Optimization.remake(prob, u0 = res.u)
 res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
-V_func, V̇_func, ∇V_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = NumericalNeuralLyapunovFunctions(
     discretization.phi,
     res.u,
-    network_func,
     structure,
     f,
     zeros(length(lb))

--- a/test/roa_estimation.jl
+++ b/test/roa_estimation.jl
@@ -66,7 +66,7 @@ prob = Optimization.remake(prob, u0 = res.u)
 res = Optimization.solve(prob, BFGS(); maxiters = 300)
 
 ###################### Get numerical numerical functions ######################
-V_func, V̇_func = NumericalNeuralLyapunovFunctions(
+V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
     res.u,
     structure,

--- a/test/roa_estimation.jl
+++ b/test/roa_estimation.jl
@@ -68,7 +68,7 @@ res = Optimization.solve(prob, BFGS(); maxiters = 300)
 ###################### Get numerical numerical functions ######################
 V_func, V̇_func = get_numerical_lyapunov_function(
     discretization.phi,
-    res.u,
+    res.u.depvar,
     structure,
     f,
     zeros(length(lb))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,4 +16,7 @@ using SafeTestsets
     @time @safetestset "Policy search - inverted pendulum 2" begin
         include("inverted_pendulum_ODESystem.jl")
     end
+    @time @safetestset "Local Lyapunov function search" begin
+        include("local_lyapunov.jl")
+    end
 end


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Changes

Various interface/performance changes, including:

- Added `name` keyword to `NeuralLyapunovPDESystem` and removed neural network function output for that function (so now it only outputs a `PDESystem`)
- Moved `NumericalNeuralLyapunovFunctions` to its own file and renamed it `get_numerical_lyapunov_function`; combined methods into one and changed parameter input (now takes `res.u.depvar` instead of `res.u`)
- Changed documentation from indicitave to imperative mood
- Changed `relu` keyword to `rectifier`
- Changed pendulum parameters in tests to match convention
- Modified tests to improve code coverage (`damped_sho.jl` now uses `ExponentialDecrease` and `damped_pendulum.jl` now uses a softplus-like rectifier)

Additionally, cleaned up `local_Lyapunov` (now `local_lyapunov`):
- Renamed 
- Added a test 
- Removed its $\nabla V$ output 
- Changed its $\dot{V}$ calculation
- Split different Jacobian handling into separate methods