### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,2 +1,0 @@
-# See https://domluna.github.io/JuliaFormatter.jl/stable/ for a list of options
-style = "sciml"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,0 +1,19 @@
+name: format-check
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'main'
+      - 'release-'
+    tags: '*'
+  pull_request:
+
+jobs:
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,12 +3,15 @@ using NeuralLyapunovProblemLibrary
 using Documenter, DocumenterCitations
 
 DocMeta.setdocmeta!(
-    NeuralLyapunov, :DocTestSetup, :(using NeuralLyapunov); recursive = true)
+    NeuralLyapunov, :DocTestSetup, :(using NeuralLyapunov); recursive = true
+)
 DocMeta.setdocmeta!(
     NeuralLyapunovProblemLibrary,
     :DocTestSetup,
-    :(using NeuralLyapunovProblemLibrary, ModelingToolkit, OrdinaryDiffEq, Random;
-    Random.seed!(200));
+    :(
+        using NeuralLyapunovProblemLibrary, ModelingToolkit, OrdinaryDiffEq, Random;
+        Random.seed!(200)
+    );
     recursive = true
 )
 
@@ -20,19 +23,19 @@ MANUAL_PAGES = [
     "man/structure.md",
     "man/roa.md",
     "man/policy_search.md",
-    "man/local_lyapunov.md"
+    "man/local_lyapunov.md",
 ]
 DEMONSTRATION_PAGES = [
     "demos/damped_SHO.md",
     "demos/roa_estimation.md",
     "demos/policy_search.md",
-    "demos/benchmarking.md"
+    "demos/benchmarking.md",
 ]
 NEURALLYAPUNOVPROBLEMLIBRARY_PAGES = [
     "lib.md",
     "lib/pendulum.md",
     "lib/double_pendulum.md",
-    "lib/quadrotor.md"
+    "lib/quadrotor.md",
 ]
 
 bib = CitationBibliography(
@@ -53,7 +56,7 @@ makedocs(;
         "Home" => "index.md",
         "Manual" => vcat(MANUAL_PAGES, hide("man/internals.md")),
         "Demonstrations" => DEMONSTRATION_PAGES,
-        "Test Problem Library" => NEURALLYAPUNOVPROBLEMLIBRARY_PAGES
+        "Test Problem Library" => NEURALLYAPUNOVPROBLEMLIBRARY_PAGES,
     ],
     plugins = [bib]
 )

--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/NeuralLyapunovProblemLibraryPlotsExt.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/NeuralLyapunovProblemLibraryPlotsExt.jl
@@ -2,10 +2,10 @@ module NeuralLyapunovProblemLibraryPlotsExt
 
 import NeuralLyapunovProblemLibrary
 using NeuralLyapunovProblemLibrary: plot_pendulum, plot_double_pendulum,
-                                    plot_quadrotor_planar, plot_quadrotor_3d
+    plot_quadrotor_planar, plot_quadrotor_3d
 import Plots
 using Plots: Shape, plot, plot!, quiver!, scatter!, annotate!, @animate, title!, xlims,
-             xlims!, ylims, ylims!, zlims, zlims!
+    xlims!, ylims, ylims!, zlims, zlims!
 using Rotations: RotZXY
 
 include("pendulum_plot.jl")

--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/double_pendulum_plot.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/double_pendulum_plot.jl
@@ -25,7 +25,7 @@ function NeuralLyapunovProblemLibrary.plot_double_pendulum(
         N = 500,
         angle1_symbol = :θ1,
         angle2_symbol = :θ2
-)
+    )
     t = LinRange(sol.t[1], sol.t[end], N)
     θ1 = sol(t)[angle1_symbol]
     θ2 = sol(t)[angle2_symbol]
@@ -66,6 +66,6 @@ function NeuralLyapunovProblemLibrary.plot_double_pendulum(θ1, θ2, p, t; title
         xlims!(-L, L)
         ylims!(-L, L)
         title!(title)
-        annotate!(-0.5L, 0.75L, "time= $(rpad(round(t[i]; digits=1),4,"0"))")
+        annotate!(-0.5L, 0.75L, "time= $(rpad(round(t[i]; digits = 1), 4, "0"))")
     end
 end

--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/pendulum_plot.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/pendulum_plot.jl
@@ -16,7 +16,8 @@ Plot the pendulum's trajectory.
   - `angle_symbol`: The symbol of the angle in `sol`; defaults to `:θ`.
 """
 function NeuralLyapunovProblemLibrary.plot_pendulum(
-        sol; title = "", N = 500, angle_symbol = :θ)
+        sol; title = "", N = 500, angle_symbol = :θ
+    )
     t = LinRange(sol.t[1], sol.t[end], N)
     θ = sol(t)[angle_symbol]
     return plot_pendulum(θ, t; title)
@@ -50,6 +51,6 @@ function NeuralLyapunovProblemLibrary.plot_pendulum(θ, t; title = "")
         xlims!(-1.5, 1.5)
         ylims!(-1.5, 1.5)
         title!(title)
-        annotate!(-0.75, 1.25, "time= $(rpad(round(t[i]; digits=1),4,"0"))")
+        annotate!(-0.75, 1.25, "time= $(rpad(round(t[i]; digits = 1), 4, "0"))")
     end
 end

--- a/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/quadrotor_plot.jl
+++ b/lib/NeuralLyapunovProblemLibrary/ext/NeuralLyapunovProblemLibraryPlotsExt/quadrotor_plot.jl
@@ -37,7 +37,7 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_planar(
         θ_symbol = :θ,
         u1_symbol = :u1,
         u2_symbol = :u2
-)
+    )
     t = LinRange(sol.t[1], sol.t[end], N)
     x = sol(t)[x_symbol]
     y = sol(t)[y_symbol]
@@ -55,7 +55,8 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_planar(x, y, θ, p, t; titl
 end
 
 function NeuralLyapunovProblemLibrary.plot_quadrotor_planar(
-        x, y, θ, u1, u2, p, t; title = "")
+        x, y, θ, u1, u2, p, t; title = ""
+    )
     function quadrotor_body(x, y, θ, r; aspect_ratio = 10)
         pos = [x, y]
         r_vec = [r * cos(θ), r * sin(θ)]
@@ -79,7 +80,7 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_planar(
         arrow2 = [arrow2_begin, arrow2_end]
         return (
             (first.(arrow1), last.(arrow1)),
-            (first.(arrow2), last.(arrow2))
+            (first.(arrow2), last.(arrow2)),
         )
     end
 
@@ -168,7 +169,7 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_3d(
         τφ_symbol = :τφ,
         τθ_symbol = :τθ,
         τψ_symbol = :τψ
-)
+    )
     t = LinRange(sol.t[1], sol.t[end], N)
     x = sol(t)[x_symbol]
     y = sol(t)[y_symbol]
@@ -185,7 +186,7 @@ end
 
 function NeuralLyapunovProblemLibrary.plot_quadrotor_3d(
         x, y, z, φ, θ, ψ, p, t; title = ""
-)
+    )
     m, g = p[1:2]
     T = fill(m * g / 4, length(t))
     τφ = zeros(length(t))
@@ -196,7 +197,7 @@ end
 
 function NeuralLyapunovProblemLibrary.plot_quadrotor_3d(
         x, y, z, φ, θ, ψ, T, τφ, τθ, τψ, p, t; title = ""
-)
+    )
     m, g = p[1:2]
     L = 1.0
     k = 1.0
@@ -260,7 +261,7 @@ function NeuralLyapunovProblemLibrary.plot_quadrotor_3d(
             quiver = (
                 [F1[1], F2[1], F3[1], F4[1]],
                 [F1[2], F2[2], F3[2], F4[2]],
-                [F1[3], F2[3], F3[3], F4[3]]
+                [F1[3], F2[3], F3[3], F4[3]],
             ),
             markersize = 3,
             markershape = :utriangle,

--- a/lib/NeuralLyapunovProblemLibrary/src/double_pendulum.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/double_pendulum.jl
@@ -49,14 +49,20 @@ function DoublePendulum(; actuation = :fully_actuated, name, defaults = NullPara
     DDt = Dt^2
 
     @variables θ1(t) θ2(t)
-    @parameters I1 I2 l1 l2 lc1 lc2 m1 m2 g=9.81
+    @parameters I1 I2 l1 l2 lc1 lc2 m1 m2 g = 9.81
 
-    M = [I1+I2+m2*l1^2+2*m2*l1*lc2*cos(θ2) I2+m2 * l1 * lc2 * cos(θ2);
-         I2+m2 * l1 * lc2 * cos(θ2) I2]
-    C = [-2*m2*l1*lc2*sin(θ2)*Dt(θ2) -m2*l1*lc2*sin(θ2)*Dt(θ2);
-         m2*l1*lc2*sin(θ2)*Dt(θ1) 0]
-    G = [-m1 * g * lc1 * sin(θ1) - m2 * g * (l1 * sin(θ1) + lc2 * sin(θ1 + θ2));
-         -m2 * g * lc2 * sin(θ1 + θ2)]
+    M = [
+        I1 + I2 + m2 * l1^2 + 2 * m2 * l1 * lc2 * cos(θ2) I2 + m2 * l1 * lc2 * cos(θ2);
+        I2 + m2 * l1 * lc2 * cos(θ2) I2
+    ]
+    C = [
+        -2 * m2 * l1 * lc2 * sin(θ2) * Dt(θ2) -m2 * l1 * lc2 * sin(θ2) * Dt(θ2);
+        m2 * l1 * lc2 * sin(θ2) * Dt(θ1) 0
+    ]
+    G = [
+        -m1 * g * lc1 * sin(θ1) - m2 * g * (l1 * sin(θ1) + lc2 * sin(θ1 + θ2));
+        -m2 * g * lc2 * sin(θ1 + θ2)
+    ]
     q = [θ1, θ2]
     params = [I1, I2, l1, l2, lc1, lc2, m1, m2, g]
 
@@ -117,7 +123,7 @@ end
 Alias for [`DoublePendulum(; actuation = :pendubot, name, defaults)`](@ref).
 """
 function Pendubot(; name, defaults = NullParameters())
-    DoublePendulum(; actuation = :pendubot, name, defaults)
+    return DoublePendulum(; actuation = :pendubot, name, defaults)
 end
 
 """

--- a/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
+++ b/lib/NeuralLyapunovProblemLibrary/src/quadrotor.jl
@@ -47,9 +47,11 @@ function QuadrotorPlanar(; name, defaults = NullParameters())
     ũ1 = max(0, u1)
     ũ2 = max(0, u2)
 
-    eqs = [m * DDt(x) ~ -(ũ1 + ũ2) * sin(θ);
-           m * DDt(y) ~ (ũ1 + ũ2) * cos(θ) - m * g;
-           I_quad * DDt(θ) ~ r * (ũ1 - ũ2)]
+    eqs = [
+        m * DDt(x) ~ -(ũ1 + ũ2) * sin(θ);
+        m * DDt(y) ~ (ũ1 + ũ2) * cos(θ) - m * g;
+        I_quad * DDt(θ) ~ r * (ũ1 - ũ2)
+    ]
 
     params = [m, I_quad, g, r]
     kwargs = if defaults == NullParameters()
@@ -151,7 +153,7 @@ function Quadrotor3D(; name, defaults = NullParameters())
 
     # Parameters
     # m-mass, g-gravitational accelerationz
-    @parameters m g=9.81 Ixx Ixy Ixz Iyy Iyz Izz
+    @parameters m g = 9.81 Ixx Ixy Ixz Iyy Iyz Izz
     params = [m, g, Ixx, Ixy, Ixz, Iyy, Iyz, Izz]
     g_vec = [0, 0, -g]
     inertia_matrix = [Ixx Ixy Ixz; Ixy Iyy Iyz; Ixz Ixy Izz]

--- a/lib/NeuralLyapunovProblemLibrary/test/double_pendulum_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/double_pendulum_test.jl
@@ -18,8 +18,10 @@ end
 function T(x, p)
     θ1, θ2, ω1, ω2 = x
     I1, I2, l1, l2, lc1, lc2, m1, m2, g = p
-    M = [I1+I2+m2*l1^2+2*m2*l1*lc2*cos(θ2) I2+m2 * l1 * lc2 * cos(θ2);
-         I2+m2 * l1 * lc2 * cos(θ2) I2]
+    M = [
+        I1 + I2 + m2 * l1^2 + 2 * m2 * l1 * lc2 * cos(θ2) I2 + m2 * l1 * lc2 * cos(θ2);
+        I2 + m2 * l1 * lc2 * cos(θ2) I2
+    ]
     return 0.5 * dot([ω1, ω2], M, [ω1, ω2])
 end
 E(x, p) = T(x, p) + U(x, p)
@@ -44,7 +46,7 @@ g = 1.0
 p = Dict(parameters(double_pendulum_undriven) .=> [I1, I2, l1, l2, lc1, lc2, m1, m2, g])
 
 prob = ODEProblem(structural_simplify(double_pendulum_undriven), x0, 100, p)
-sol = solve(prob, Tsit5(), abstol = 1e-10, reltol = 1e-10)
+sol = solve(prob, Tsit5(), abstol = 1.0e-10, reltol = 1.0e-10)
 
 # Test energy conservation
 x = vcat(sol[θ1]', sol[θ2]', sol[Dt(θ1)]', sol[Dt(θ2)]')
@@ -64,7 +66,7 @@ plot(
 =#
 
 avg_energy = sum(total_energy) / length(total_energy)
-@test maximum(abs, total_energy .- avg_energy) / abs(avg_energy) < 1e-4
+@test maximum(abs, total_energy .- avg_energy) / abs(avg_energy) < 1.0e-4
 
 # Test plotting extension
 anim = plot_double_pendulum(sol, p)
@@ -79,15 +81,19 @@ println("Double pendulum feedback cancellation test")
 function π_cancellation(x, p)
     θ1, θ2, ω1, ω2 = x
     I1, I2, l1, l2, lc1, lc2, m1, m2, g = p
-    M = [I1+I2+m2*l1^2+2*m2*l1*lc2*cos(θ2) I2+m2 * l1 * lc2 * cos(θ2);
-         I2+m2 * l1 * lc2 * cos(θ2) I2]
-    G = [-m1 * g * lc1 * sin(θ1) - m2 * g * (l1 * sin(θ1) + lc2 * sin(θ1 + θ2));
-         -m2 * g * lc2 * sin(θ1 + θ2)]
+    M = [
+        I1 + I2 + m2 * l1^2 + 2 * m2 * l1 * lc2 * cos(θ2) I2 + m2 * l1 * lc2 * cos(θ2);
+        I2 + m2 * l1 * lc2 * cos(θ2) I2
+    ]
+    G = [
+        -m1 * g * lc1 * sin(θ1) - m2 * g * (l1 * sin(θ1) + lc2 * sin(θ1 + θ2));
+        -m2 * g * lc2 * sin(θ1 + θ2)
+    ]
     return -0.1 * M \ ([θ1, θ2] .- [π, π] + [ω1, ω2]) - G
 end
 
 double_pendulum_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     double_pendulum,
     (inputs(double_pendulum), []);
     simplify = true,
@@ -111,7 +117,8 @@ x = [double_pendulum.θ1, double_pendulum.θ2, Dt(double_pendulum.θ1), Dt(doubl
     p
 )
 @named double_pendulum_feedback_cancellation = compose(
-    cancellation_controller, double_pendulum)
+    cancellation_controller, double_pendulum
+)
 double_pendulum_feedback_cancellation = structural_simplify(double_pendulum_feedback_cancellation)
 
 # Swing up to upward equilibrium
@@ -132,10 +139,10 @@ sol = solve(prob, Tsit5())
 x1_end, y1_end = sin(θ1_end), -cos(θ1_end)
 θ2_end, ω2_end = sol[:double_pendulum₊θ2][end], sol.u[end][4]
 x2_end, y2_end = sin(θ2_end), -cos(θ2_end)
-@test sqrt(sum(abs2, [x1_end, y1_end] .- [0, 1]))≈0 atol=1e-4
-@test sqrt(sum(abs2, [x2_end, y2_end] .- [0, 1]))≈0 atol=1e-4
-@test ω1_end≈0 atol=1e-4
-@test ω2_end≈0 atol=1e-4
+@test sqrt(sum(abs2, [x1_end, y1_end] .- [0, 1])) ≈ 0 atol = 1.0e-4
+@test sqrt(sum(abs2, [x2_end, y2_end] .- [0, 1])) ≈ 0 atol = 1.0e-4
+@test ω1_end ≈ 0 atol = 1.0e-4
+@test ω2_end ≈ 0 atol = 1.0e-4
 
 #=
 gif(
@@ -157,14 +164,20 @@ function acrobot_lqr_matrix(p; x_eq = [π, 0, 0, 0], Q = I(4), R = I(1))
     θ1, θ2 = x_eq[1:2]
 
     # Assumes linearization around a fixed point
-    M = [I1+I2+m2*l1^2+2*m2*l1*lc2*cos(θ2) I2+m2 * l1 * lc2 * cos(θ2);
-         I2+m2 * l1 * lc2 * cos(θ2) I2]
+    M = [
+        I1 + I2 + m2 * l1^2 + 2 * m2 * l1 * lc2 * cos(θ2) I2 + m2 * l1 * lc2 * cos(θ2);
+        I2 + m2 * l1 * lc2 * cos(θ2) I2
+    ]
     B = [0, 1]
-    Jτ_g = [-m1 * g * lc1 * cos(θ1)-m2 * g * (l1 * cos(θ1) + lc2 * cos(θ1 + θ2)) -m2*g*lc2*cos(θ1 + θ2);
-            -m2*g*lc2*cos(θ1 + θ2) -m2*g*lc2*cos(θ1 + θ2)]
+    Jτ_g = [
+        -m1 * g * lc1 * cos(θ1) - m2 * g * (l1 * cos(θ1) + lc2 * cos(θ1 + θ2)) -m2 * g * lc2 * cos(θ1 + θ2);
+        -m2 * g * lc2 * cos(θ1 + θ2) -m2 * g * lc2 * cos(θ1 + θ2)
+    ]
 
-    A_lin = [zeros(2, 2) I(2);
-             M\Jτ_g zeros(2, 2)]
+    A_lin = [
+        zeros(2, 2) I(2);
+        M \ Jτ_g zeros(2, 2)
+    ]
     B_lin = [zeros(2); M \ B]
 
     return lqr(Continuous, A_lin, B_lin, Q, R)
@@ -178,7 +191,7 @@ end
 @named acrobot = Acrobot()
 
 acrobot_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     acrobot,
     (inputs(acrobot), []);
     simplify = true,
@@ -221,7 +234,8 @@ prob = ODEProblem(acrobot_lqr, Dict(x .=> x0), tspan, Dict(params .=> p))
 sol = solve(prob, Tsit5())
 
 anim = plot_double_pendulum(
-    sol, p; angle1_symbol = :acrobot₊θ1, angle2_symbol = :acrobot₊θ2)
+    sol, p; angle1_symbol = :acrobot₊θ1, angle2_symbol = :acrobot₊θ2
+)
 @test anim isa Plots.Animation
 # gif(anim, fps=50)
 
@@ -229,7 +243,7 @@ x1_end, y1_end = sin(sol[acrobot.θ1][end]), -cos(sol[acrobot.θ1][end])
 ω1_end = sol[Dt(acrobot.θ1)][end]
 x2_end, y2_end = sin(sol[acrobot.θ2][end]), -cos(sol[acrobot.θ2][end])
 ω2_end = sol[Dt(acrobot.θ2)][end]
-@test sqrt(sum(abs2, [x1_end, y1_end] .- [0, 1]))≈0 atol=1e-4
-@test sqrt(sum(abs2, [x2_end, y2_end] .- [0, 1]))≈0 atol=1e-4
-@test ω1_end≈0 atol=1e-4
-@test ω2_end≈0 atol=1e-4
+@test sqrt(sum(abs2, [x1_end, y1_end] .- [0, 1])) ≈ 0 atol = 1.0e-4
+@test sqrt(sum(abs2, [x2_end, y2_end] .- [0, 1])) ≈ 0 atol = 1.0e-4
+@test ω1_end ≈ 0 atol = 1.0e-4
+@test ω2_end ≈ 0 atol = 1.0e-4

--- a/lib/NeuralLyapunovProblemLibrary/test/pendulum_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/pendulum_test.jl
@@ -18,8 +18,8 @@ p = rand(rng, 2)
 prob = ODEProblem(structural_simplify(pendulum_undriven), x0, 15τ, p)
 sol = solve(prob, Tsit5())
 x_end, y_end, ω_end = sin(sol.u[end][1]), -cos(sol.u[end][1]), sol.u[end][2]
-@test sqrt(sum(abs2, [x_end, y_end] .- [0, -1]))≈0 atol=1e-4
-@test ω_end≈0 atol=1e-4
+@test sqrt(sum(abs2, [x_end, y_end] .- [0, -1])) ≈ 0 atol = 1.0e-4
+@test ω_end ≈ 0 atol = 1.0e-4
 
 anim = plot_pendulum(sol)
 @test anim isa Plots.Animation
@@ -33,7 +33,7 @@ println("Simple pendulum feedback cancellation test")
 π_cancellation(x, p) = 2 * p[2]^2 * sin(x[1])
 
 pendulum_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     pendulum,
     (inputs(pendulum), []);
     simplify = true,
@@ -65,5 +65,5 @@ p = rand(rng, 2)
 prob = ODEProblem(pendulum_feedback_cancellation, x0, 15τ, p)
 sol = solve(prob, Tsit5())
 x_end, y_end, ω_end = sin(sol.u[end][1]), -cos(sol.u[end][1]), sol.u[end][2]
-@test sqrt(sum(abs2, [x_end, y_end] .- [0, 1]))≈0 atol=1e-4
-@test ω_end≈0 atol=1e-4
+@test sqrt(sum(abs2, [x_end, y_end] .- [0, 1])) ≈ 0 atol = 1.0e-4
+@test ω_end ≈ 0 atol = 1.0e-4

--- a/lib/NeuralLyapunovProblemLibrary/test/planar_quadrotor_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/planar_quadrotor_test.jl
@@ -23,7 +23,7 @@ function π_vertical_only(x, p; y_goal = 0.0, k_p = 1.0, k_d = 1.0)
 end
 
 quadrotor_planar_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     quadrotor_planar,
     (inputs(quadrotor_planar), []);
     simplify = true,
@@ -35,7 +35,8 @@ Dt = Differential(t)
 q = setdiff(unknowns(quadrotor_planar), inputs(quadrotor_planar))
 
 params = map(
-    Base.Fix1(getproperty, quadrotor_planar), toexpr.(parameters(quadrotor_planar)))
+    Base.Fix1(getproperty, quadrotor_planar), toexpr.(parameters(quadrotor_planar))
+)
 u = map(
     Base.Fix1(getproperty, quadrotor_planar),
     toexpr.(getproperty.(inputs(quadrotor_planar_simplified), :f))
@@ -72,12 +73,12 @@ sol = solve(prob, Tsit5())
 
 x_end, y_end, θ_end = sol[q][end]
 v_x_end, v_y_end, v_θ_end = sol[Dt.(q)][end]
-@test x_end≈0.0 atol=1e-4
-@test y_end≈0.0 atol=1e-4
-@test θ_end≈0.0 atol=1e-4
-@test v_x_end≈0.0 atol=1e-4
-@test v_y_end≈0.0 atol=1e-4
-@test v_θ_end≈0.0 atol=1e-4
+@test x_end ≈ 0.0 atol = 1.0e-4
+@test y_end ≈ 0.0 atol = 1.0e-4
+@test θ_end ≈ 0.0 atol = 1.0e-4
+@test v_x_end ≈ 0.0 atol = 1.0e-4
+@test v_y_end ≈ 0.0 atol = 1.0e-4
+@test v_θ_end ≈ 0.0 atol = 1.0e-4
 
 anim = plot_quadrotor_planar(
     sol,
@@ -120,7 +121,7 @@ end
 @named quadrotor_planar = QuadrotorPlanar()
 
 quadrotor_planar_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     quadrotor_planar,
     (inputs(quadrotor_planar), []);
     simplify = true,
@@ -131,7 +132,8 @@ t, = independent_variables(quadrotor_planar)
 Dt = Differential(t)
 q = setdiff(unknowns(quadrotor_planar), inputs(quadrotor_planar))
 params = map(
-    Base.Fix1(getproperty, quadrotor_planar), toexpr.(parameters(quadrotor_planar)))
+    Base.Fix1(getproperty, quadrotor_planar), toexpr.(parameters(quadrotor_planar))
+)
 u = map(
     Base.Fix1(getproperty, quadrotor_planar),
     toexpr.(getproperty.(inputs(quadrotor_planar_simplified), :f))
@@ -168,12 +170,12 @@ sol = solve(prob, Tsit5())
 
 x_end, y_end, θ_end = sol[q][end]
 v_x_end, v_y_end, v_θ_end = sol[Dt.(q)][end]
-@test x_end≈0.0 atol=1e-4
-@test y_end≈0.0 atol=1e-4
-@test θ_end≈0.0 atol=1e-4
-@test v_x_end≈0.0 atol=1e-4
-@test v_y_end≈0.0 atol=1e-4
-@test v_θ_end≈0.0 atol=1e-4
+@test x_end ≈ 0.0 atol = 1.0e-4
+@test y_end ≈ 0.0 atol = 1.0e-4
+@test θ_end ≈ 0.0 atol = 1.0e-4
+@test v_x_end ≈ 0.0 atol = 1.0e-4
+@test v_y_end ≈ 0.0 atol = 1.0e-4
+@test v_θ_end ≈ 0.0 atol = 1.0e-4
 
 anim = plot_quadrotor_planar(
     sol,

--- a/lib/NeuralLyapunovProblemLibrary/test/qa_tests.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/qa_tests.jl
@@ -10,12 +10,13 @@ end
     using ExplicitImports
 
     @test check_no_implicit_imports(NeuralLyapunovProblemLibrary; skip = (Base, Core)) ===
-          nothing
+        nothing
     @test check_no_stale_explicit_imports(NeuralLyapunovProblemLibrary) === nothing
     @test check_no_self_qualified_accesses(NeuralLyapunovProblemLibrary) === nothing
     @test check_all_explicit_imports_via_owners(NeuralLyapunovProblemLibrary) === nothing
     @test check_all_qualified_accesses_via_owners(NeuralLyapunovProblemLibrary) === nothing
     @test check_all_explicit_imports_are_public(
-        NeuralLyapunovProblemLibrary; ignore = (:NullParameters,)) === nothing
+        NeuralLyapunovProblemLibrary; ignore = (:NullParameters,)
+    ) === nothing
     @test check_all_qualified_accesses_are_public(NeuralLyapunovProblemLibrary) === nothing
 end

--- a/lib/NeuralLyapunovProblemLibrary/test/quadrotor_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/quadrotor_test.jl
@@ -32,7 +32,7 @@ end
 @named quadrotor_3d = Quadrotor3D()
 
 quadrotor_3d_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     quadrotor_3d,
     (inputs(quadrotor_3d), []);
     simplify = true,
@@ -85,17 +85,17 @@ sol = solve(prob, Tsit5())
 
 x_end, y_end, z_end, φ_end, θ_end, ψ_end = sol[q][end]
 vx_end, vy_end, vz_end, ωφ_end, ωθ_end, ωψ_end = sol[q̇][end]
-@test x_end≈0.0 atol=1e-4
-@test y_end≈0.0 atol=1e-4
-@test z_end≈0.0 atol=1e-4
-@test φ_end≈0.0 atol=1e-4
-@test θ_end≈0.0 atol=1e-4
-@test vx_end≈0.0 atol=1e-4
-@test vy_end≈0.0 atol=1e-4
-@test vz_end≈0.0 atol=1e-4
-@test ωφ_end≈0.0 atol=1e-4
-@test ωθ_end≈0.0 atol=1e-4
-@test ωψ_end≈x0[q̇[6]] atol=1e-4
+@test x_end ≈ 0.0 atol = 1.0e-4
+@test y_end ≈ 0.0 atol = 1.0e-4
+@test z_end ≈ 0.0 atol = 1.0e-4
+@test φ_end ≈ 0.0 atol = 1.0e-4
+@test θ_end ≈ 0.0 atol = 1.0e-4
+@test vx_end ≈ 0.0 atol = 1.0e-4
+@test vy_end ≈ 0.0 atol = 1.0e-4
+@test vz_end ≈ 0.0 atol = 1.0e-4
+@test ωφ_end ≈ 0.0 atol = 1.0e-4
+@test ωθ_end ≈ 0.0 atol = 1.0e-4
+@test ωψ_end ≈ x0[q̇[6]] atol = 1.0e-4
 
 anim = plot_quadrotor_3d(
     sol,
@@ -123,7 +123,7 @@ function quadrotor_3d_lqr_matrix(
         u_eq = [p[1] * p[2], 0, 0, 0],
         Q = I(12),
         R = I(4)
-)
+    )
     u = inputs(quadrotor_3d)
     x = setdiff(unknowns(quadrotor_3d), u)
     params = parameters(quadrotor_3d)
@@ -153,7 +153,7 @@ end
 @named quadrotor_3d = Quadrotor3D()
 
 quadrotor_3d_simplified,
-_ = structural_simplify(
+    _ = structural_simplify(
     quadrotor_3d,
     (inputs(quadrotor_3d), []);
     simplify = true,
@@ -204,18 +204,18 @@ sol = solve(prob, Tsit5())
 
 x_end, y_end, z_end, φ_end, θ_end, ψ_end = sol[q][end]
 vx_end, vy_end, vz_end, ωφ_end, ωθ_end, ωψ_end = sol[q̇][end]
-@test x_end≈0.0 atol=1e-4
-@test y_end≈0.0 atol=1e-4
-@test z_end≈0.0 atol=1e-4
-@test φ_end≈0.0 atol=1e-4
-@test θ_end≈0.0 atol=1e-4
-@test ψ_end≈0.0 atol=1e-4
-@test vx_end≈0.0 atol=1e-4
-@test vy_end≈0.0 atol=1e-4
-@test vz_end≈0.0 atol=1e-4
-@test ωφ_end≈0.0 atol=1e-4
-@test ωθ_end≈0.0 atol=1e-4
-@test ωψ_end≈0.0 atol=1e-4
+@test x_end ≈ 0.0 atol = 1.0e-4
+@test y_end ≈ 0.0 atol = 1.0e-4
+@test z_end ≈ 0.0 atol = 1.0e-4
+@test φ_end ≈ 0.0 atol = 1.0e-4
+@test θ_end ≈ 0.0 atol = 1.0e-4
+@test ψ_end ≈ 0.0 atol = 1.0e-4
+@test vx_end ≈ 0.0 atol = 1.0e-4
+@test vy_end ≈ 0.0 atol = 1.0e-4
+@test vz_end ≈ 0.0 atol = 1.0e-4
+@test ωφ_end ≈ 0.0 atol = 1.0e-4
+@test ωθ_end ≈ 0.0 atol = 1.0e-4
+@test ωψ_end ≈ 0.0 atol = 1.0e-4
 
 anim = plot_quadrotor_3d(
     sol,

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -6,10 +6,10 @@ using LinearAlgebra: I, dot, ⋅
 import Symbolics
 using Symbolics: @variables, Equation, Num, diff2term, value
 using ModelingToolkit: @named, @parameters, ODESystem, PDESystem, parameters, unknowns,
-                       defaults, operation, unbound_inputs, defaults, structural_simplify
+    defaults, operation, unbound_inputs, defaults, structural_simplify
 import SciMLBase
 using SciMLBase: ODEFunction, ODEInputFunction, ODEProblem, solve, EnsembleProblem,
-                 EnsembleThreads, remake
+    EnsembleThreads, remake
 
 using SymbolicIndexingInterface: SymbolCache, variable_symbols
 using NeuralPDE: PhysicsInformedNN, discretize, LogOptions
@@ -40,19 +40,19 @@ include("lux_structures.jl")
 
 # Lyapunov function structures
 export NeuralLyapunovStructure, NoAdditionalStructure, NonnegativeStructure,
-       PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
+    PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
 
 # Lux structures
 export AdditiveLyapunovNet, MultiplicativeLyapunovNet, SoSPooling,
-       StrictlyPositiveSoSPooling
+    StrictlyPositiveSoSPooling
 
 # Minimization conditions
 export LyapunovMinimizationCondition, StrictlyPositiveDefinite, PositiveSemiDefinite,
-       DontCheckNonnegativity
+    DontCheckNonnegativity
 
 # Decrease conditions
 export LyapunovDecreaseCondition, StabilityISL, AsymptoticStability, ExponentialStability,
-       DontCheckDecrease
+    DontCheckDecrease
 
 # Setting up the PDESystem for NeuralPDE
 export NeuralLyapunovSpecification, NeuralLyapunovPDESystem

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -49,7 +49,7 @@ function NeuralLyapunovPDESystem(
         parameter_syms = [],
         policy_search::Bool = false,
         name
-)::PDESystem
+    )::PDESystem
     ########################## Define state symbols ###########################
     state_dim = length(lb)
 
@@ -110,17 +110,29 @@ function NeuralLyapunovPDESystem(
         parameter_syms = [],
         policy_search::Bool = dynamics isa ODEInputFunction,
         name
-)::PDESystem
+    )::PDESystem
     if dynamics.mass_matrix !== I
-        throw(ErrorException("DAEs are not supported at this time. Please supply dynamics" *
-                             " without a mass matrix."))
+        throw(
+            ErrorException(
+                "DAEs are not supported at this time. Please supply dynamics" *
+                    " without a mass matrix."
+            )
+        )
     end
     if policy_search && (dynamics isa ODEFunction)
-        throw(ErrorException("Got policy_search == true when dynamics were supplied as an" *
-                             " ODEFunction f(x,p,t), so no input can be supplied."))
+        throw(
+            ErrorException(
+                "Got policy_search == true when dynamics were supplied as an" *
+                    " ODEFunction f(x,p,t), so no input can be supplied."
+            )
+        )
     elseif !policy_search && (dynamics isa ODEInputFunction)
-        throw(ErrorException("Got policy_search == false when dynamics were supplied as " *
-                             "an ODEInputFunction f(x,u,p,t)."))
+        throw(
+            ErrorException(
+                "Got policy_search == false when dynamics were supplied as " *
+                    "an ODEInputFunction f(x,u,p,t)."
+            )
+        )
     end
 
     # Extract state and parameter symbols from ODEFunction/ODEInputFunction
@@ -172,15 +184,16 @@ function NeuralLyapunovPDESystem(
         spec::NeuralLyapunovSpecification;
         fixed_point = zeros(length(bounds)),
         name
-)::PDESystem
+    )::PDESystem
     ######################### Check for policy search #########################
     policy_search = !isempty(unbound_inputs(dynamics))
 
     f,
-    x = if policy_search
+        x = if policy_search
         dynamics_io_sys,
-        _ = structural_simplify(
-            dynamics, (unbound_inputs(dynamics), []); split = false)
+            _ = structural_simplify(
+            dynamics, (unbound_inputs(dynamics), []); split = false
+        )
         (ODEInputFunction(dynamics_io_sys), unknowns(dynamics_io_sys))
     else
         (ODEFunction(dynamics), unknowns(dynamics))
@@ -200,8 +213,10 @@ function NeuralLyapunovPDESystem(
     )
     domain_vars = map(d -> d.variables, domains)
     if Set(_state) != Set(domain_vars)
-        error("Domain variables from `domains` do not match those extracted from " *
-              "`dynamics`. Got $_state from `dynamics` and $domain_vars from `domains`.")
+        error(
+            "Domain variables from `domains` do not match those extracted from " *
+                "`dynamics`. Got $_state from `dynamics` and $domain_vars from `domains`."
+        )
     end
 
     ########################### Construct PDESystem ###########################
@@ -228,7 +243,7 @@ function _NeuralLyapunovPDESystem(
         defaults,
         policy_search::Bool,
         name
-)::PDESystem
+    )::PDESystem
     ########################## Unpack specifications ##########################
     structure = spec.structure
     minimization_condition = spec.minimization_condition
@@ -249,7 +264,7 @@ function _NeuralLyapunovPDESystem(
 
     # V̇(x) is the symbolic time derivative of the Lyapunov function
     function V̇(x)
-        structure.V̇(
+        return structure.V̇(
             φ,
             y -> Symbolics.jacobian(φ(y), y),
             dynamics,

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -152,7 +152,7 @@ function benchmark(
         simulation_time,
         ode_solver = Tsit5(),
         ode_solver_args = [],
-        atol = 1e-6,
+        atol = 1.0e-6,
         endpoint_check = nothing,
         classifier = (V, V̇, x) -> V̇ < zero(V̇),
         init_params = nothing,
@@ -161,14 +161,15 @@ function benchmark(
         sample_alg = LatinHypercubeSample(rng),
         ensemble_alg = EnsembleThreads(),
         log_frequency = 50
-)
+    )
     params = parameters(dynamics)
     f = if isempty(unbound_inputs(dynamics))
         ODEFunction(dynamics)
     else
         dynamics_io_sys,
-        _ = structural_simplify(
-            dynamics, (unbound_inputs(dynamics), []); split = false)
+            _ = structural_simplify(
+            dynamics, (unbound_inputs(dynamics), []); split = false
+        )
         ODEInputFunction(dynamics_io_sys; simplify = true, split = false)
     end
 
@@ -281,7 +282,7 @@ function benchmark(
         simulation_time,
         ode_solver = Tsit5(),
         ode_solver_args = [],
-        atol = 1e-6,
+        atol = 1.0e-6,
         endpoint_check = nothing,
         init_params = nothing,
         init_states = nothing,
@@ -289,7 +290,7 @@ function benchmark(
         sample_alg = LatinHypercubeSample(rng),
         ensemble_alg = EnsembleThreads(),
         log_frequency = 50
-)
+    )
     default_float_type = if simulation_time isa AbstractFloat
         typeof(simulation_time)
     elseif eltype(p) <: AbstractFloat
@@ -403,13 +404,14 @@ function _benchmark(
         ensemble_alg,
         log_frequency,
         logger
-)
+    )
     log_options = LogOptions(; log_frequency)
 
     t = @timed begin
         # Construct OptimizationProblem
         discretization = PhysicsInformedNN(
-            chain, strategy; init_params, init_states, logger, log_options)
+            chain, strategy; init_params, init_states, logger, log_options
+        )
         opt_prob = discretize(pde_system, discretization)
 
         # Solve OptimizationProblem
@@ -421,8 +423,10 @@ function _benchmark(
     end
     training_time = t.time
     θ = t.value |> cpud
-    phi = PhysicsInformedNN(chain, strategy; init_params = init_params |> cpud,
-        init_states = init_states |> cpud).phi
+    phi = PhysicsInformedNN(
+        chain, strategy; init_params = init_params |> cpud,
+        init_states = init_states |> cpud
+    ).phi
 
     V, V̇ = get_numerical_lyapunov_function(
         phi,
@@ -484,7 +488,7 @@ function _benchmark(
 
     confusion_matrix = DataFrame(
         "Classification" => [
-            "True Positives", "False Positives", "True Negatives", "False Negatives"
+            "True Positives", "False Positives", "True Negatives", "False Negatives",
         ],
         "Count" => [tp, fp, tn, fn]
     )
@@ -516,7 +520,7 @@ function benchmark_solve(
         prob,
         opt::AbstractVector,
         optimization_args::AbstractVector{<:AbstractVector}
-)
+    )
     # Solve OptimizationProblem
     res = Ref{Any}()
     for (_opt, args) in zip(opt, optimization_args)
@@ -554,7 +558,7 @@ function simulate_ensemble(
         ode_solver_args,
         ensemble_alg,
         endpoint_check
-)
+    )
     predicted = classifier.(V_samples, V̇_samples, states)
 
     ensemble_prob = EnsembleProblem(

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -70,8 +70,10 @@ Return `true` if `cond` specifies training to meet the Lyapunov minimization con
 `false` if `cond` specifies no training to meet this condition.
 """
 function check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)::Bool
-    error("check_nonnegativity not implemented for AbstractLyapunovMinimizationCondition " *
-          "of type $(typeof(cond))")
+    error(
+        "check_nonnegativity not implemented for AbstractLyapunovMinimizationCondition " *
+            "of type $(typeof(cond))"
+    )
 end
 
 """
@@ -81,8 +83,10 @@ Return `true` if `cond` specifies training for the Lyapunov function to equal ze
 fixed point, and `false` if `cond` specifies no training to meet this condition.
 """
 function check_minimal_fixed_point(cond::AbstractLyapunovMinimizationCondition)::Bool
-    error("check_minimal_fixed_point not implemented for " *
-          "AbstractLyapunovMinimizationCondition of type $(typeof(cond))")
+    error(
+        "check_minimal_fixed_point not implemented for " *
+            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))"
+    )
 end
 
 """
@@ -96,8 +100,10 @@ Note that the first input, ``V``, is a function, so the minimization condition c
 the value of the candidate Lyapunov function at multiple points.
 """
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
-    error("get_minimization_condition not implemented for " *
-          "AbstractLyapunovMinimizationCondition of type $(typeof(cond))")
+    error(
+        "get_minimization_condition not implemented for " *
+            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))"
+    )
 end
 
 """
@@ -107,8 +113,10 @@ Return `true` if `cond` specifies training to meet the Lyapunov decrease conditi
 `false` if `cond` specifies no training to meet this condition.
 """
 function check_decrease(cond::AbstractLyapunovDecreaseCondition)::Bool
-    error("check_decrease not implemented for AbstractLyapunovDecreaseCondition of type " *
-          string(typeof(cond)))
+    error(
+        "check_decrease not implemented for AbstractLyapunovDecreaseCondition of type " *
+            string(typeof(cond))
+    )
 end
 
 """
@@ -121,6 +129,8 @@ Note that the first two inputs, ``V`` and ``V̇``, are functions, so the decreas
 can depend on the value of these functions at multiple points.
 """
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
-    error("get_decrease_condition not implemented for AbstractLyapunovDecreaseCondition " *
-          "of type $(typeof(cond))")
+    error(
+        "get_decrease_condition not implemented for AbstractLyapunovDecreaseCondition " *
+            "of type $(typeof(cond))"
+    )
 end

--- a/src/decrease_conditions.jl
+++ b/src/decrease_conditions.jl
@@ -63,7 +63,7 @@ struct LyapunovDecreaseCondition{RM, S, R} <: AbstractLyapunovDecreaseCondition
 end
 
 function check_decrease(cond::LyapunovDecreaseCondition)::Bool
-    cond.check_decrease
+    return cond.check_decrease
 end
 
 function get_decrease_condition(cond::LyapunovDecreaseCondition)
@@ -118,10 +118,10 @@ The default value `rectifier = (t) -> max(zero(t), t)` exactly represents the in
 but differentiable approximations of this function may be employed.
 """
 function AsymptoticStability(;
-        C::Real = 1e-6,
+        C::Real = 1.0e-6,
         strength = (x, x0) -> C * (x - x0) ⋅ (x - x0),
         rectifier = (t) -> max(zero(t), t)
-)::LyapunovDecreaseCondition
+    )::LyapunovDecreaseCondition
     return LyapunovDecreaseCondition(
         true,
         (V, dVdt) -> dVdt,
@@ -145,7 +145,7 @@ but differentiable approximations of this function may be employed.
 function ExponentialStability(
         k::Real;
         rectifier = (t) -> max(zero(t), t)
-)::LyapunovDecreaseCondition
+    )::LyapunovDecreaseCondition
     return LyapunovDecreaseCondition(
         true,
         (V, dVdt) -> dVdt + k * V,

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -68,7 +68,7 @@ employed.
 See also: [`AbstractLyapunovDecreaseCondition`](@ref), [`LyapunovDecreaseCondition`](@ref)
 """
 struct RoAAwareDecreaseCondition{C <: AbstractLyapunovDecreaseCondition, S, R <: Real, P} <:
-       AbstractLyapunovDecreaseCondition
+    AbstractLyapunovDecreaseCondition
     cond::C
     sigmoid::S
     ρ::R
@@ -86,8 +86,8 @@ function get_decrease_condition(cond::RoAAwareDecreaseCondition)
             _V̇ = dVdt(x)
             _V̇ = _V̇ isa AbstractVector ? _V̇[] : _V̇
             return cond.sigmoid(cond.ρ - _V) * in_RoA_penalty(V, dVdt, x, fixed_point) +
-                   cond.sigmoid(_V - cond.ρ) *
-                   cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ)
+                cond.sigmoid(_V - cond.ρ) *
+                cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ)
         end
     else
         return nothing
@@ -136,7 +136,7 @@ function make_RoA_aware(
         ρ = 1.0,
         out_of_RoA_penalty = (V, dVdt, state, fixed_point, _ρ) -> 0.0,
         sigmoid = (x) -> x .≥ zero.(x)
-)::RoAAwareDecreaseCondition
+    )::RoAAwareDecreaseCondition
     return RoAAwareDecreaseCondition(
         cond,
         sigmoid,

--- a/src/local_lyapunov.jl
+++ b/src/local_lyapunov.jl
@@ -22,9 +22,13 @@ parameters and output the Jacobian of `dynamics` with respect to the state `x`.
 If `fixed_point` is not specified, it defaults to the origin, i.e., `zeros(state_dim)`.
 Parameters `p` for the dynamics should be supplied when the dynamics depend on them.
 """
-function local_lyapunov(dynamics, state_dim, optimizer_factory, jac::AbstractMatrix{T};
-        fixed_point = zeros(T, state_dim), p = SciMLBase.NullParameters()) where {T <:
-                                                                                  Number}
+function local_lyapunov(
+        dynamics, state_dim, optimizer_factory, jac::AbstractMatrix{T};
+        fixed_point = zeros(T, state_dim), p = SciMLBase.NullParameters()
+    ) where {
+        T <:
+        Number,
+    }
     model = JuMP.Model(optimizer_factory)
     JuMP.set_silent(model)
 
@@ -37,7 +41,7 @@ function local_lyapunov(dynamics, state_dim, optimizer_factory, jac::AbstractMat
     JuMP.@variable(model, Q[1:state_dim, 1:state_dim], PSD)
 
     # V̇(x) = (x - x0) ⋅ ( (P A + A^T P) * (x - x0)), so we require P A + A^T P = -Q
-    JuMP.@constraint(model, P * jac + transpose(jac) * P.==-Q)
+    JuMP.@constraint(model, P * jac + transpose(jac) * P .== -Q)
 
     # Solve the semidefinite program and get the value of P
     JuMP.optimize!(model)
@@ -58,14 +62,18 @@ function local_lyapunov(dynamics, state_dim, optimizer_factory, jac::AbstractMat
     return V, V̇
 end
 
-function local_lyapunov(dynamics, state_dim, optimizer_factory, jac;
-        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters())
+function local_lyapunov(
+        dynamics, state_dim, optimizer_factory, jac;
+        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters()
+    )
     A::AbstractMatrix = jac(fixed_point, p)
     return local_lyapunov(dynamics, state_dim, optimizer_factory, A; fixed_point, p)
 end
 
-function local_lyapunov(dynamics, state_dim, optimizer_factory;
-        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters())
+function local_lyapunov(
+        dynamics, state_dim, optimizer_factory;
+        fixed_point = zeros(state_dim), p = SciMLBase.NullParameters()
+    )
     A::AbstractMatrix = ForwardDiff.jacobian(x -> dynamics(x, p, 0.0), fixed_point)
     return local_lyapunov(dynamics, state_dim, optimizer_factory, A; fixed_point, p)
 end

--- a/src/logger.jl
+++ b/src/logger.jl
@@ -27,8 +27,10 @@ end
 NeuralLyapunovBenchmarkLogger{T}() where {T} = NeuralLyapunovBenchmarkLogger{T, Int64}()
 NeuralLyapunovBenchmarkLogger() = NeuralLyapunovBenchmarkLogger{Float64}()
 
-function NeuralPDE.logscalar(logger::NeuralLyapunovBenchmarkLogger, scalar::Real,
-        name::AbstractString, step::Integer)
+function NeuralPDE.logscalar(
+        logger::NeuralLyapunovBenchmarkLogger, scalar::Real,
+        name::AbstractString, step::Integer
+    )
     if name == "weighted_loss/full_weighted_loss"
         push!(logger.losses, scalar)
         push!(logger.iterations, step)

--- a/src/lux_structures.jl
+++ b/src/lux_structures.jl
@@ -47,7 +47,7 @@ function AdditiveLyapunovNet(
         r = SoSPooling(),
         dim_ϕ,
         kwargs...
-)
+    )
     if :dim_m in keys(kwargs)
         dim_m = kwargs[:dim_m]
         if :fixed_point in keys(kwargs)
@@ -137,7 +137,7 @@ function MultiplicativeLyapunovNet(
         m = NoOpLayer(),
         r = SoSPooling(),
         kwargs...
-)
+    )
     if :dim_m in keys(kwargs)
         dim_m = kwargs[:dim_m]
         if :fixed_point in keys(kwargs)

--- a/src/minimization_conditions.jl
+++ b/src/minimization_conditions.jl
@@ -53,11 +53,11 @@ struct LyapunovMinimizationCondition{S, R} <: AbstractLyapunovMinimizationCondit
 end
 
 function check_nonnegativity(cond::LyapunovMinimizationCondition)::Bool
-    cond.check_nonnegativity
+    return cond.check_nonnegativity
 end
 
 function check_minimal_fixed_point(cond::LyapunovMinimizationCondition)::Bool
-    cond.check_fixed_point
+    return cond.check_fixed_point
 end
 
 function get_minimization_condition(cond::LyapunovMinimizationCondition)
@@ -87,10 +87,10 @@ exactly represents ``V(x) ≥ C \\lVert x - x_0 \\rVert^2``. ``C`` defaults to `
 """
 function StrictlyPositiveDefinite(;
         check_fixed_point = true,
-        C::Real = 1e-6,
+        C::Real = 1.0e-6,
         rectifier = (t) -> max(zero(t), t)
-)::LyapunovMinimizationCondition
-    LyapunovMinimizationCondition(
+    )::LyapunovMinimizationCondition
+    return LyapunovMinimizationCondition(
         true,
         (state, fixed_point) -> C * (state - fixed_point) ⋅ (state - fixed_point),
         rectifier,
@@ -112,8 +112,8 @@ The inequality is approximated by ``\\texttt{rectifier}( -V(x) ) = 0`` and the d
 function PositiveSemiDefinite(;
         check_fixed_point = true,
         rectifier = (t) -> max(zero(t), t)
-)::LyapunovMinimizationCondition
-    LyapunovMinimizationCondition(
+    )::LyapunovMinimizationCondition
+    return LyapunovMinimizationCondition(
         true,
         (state, fixed_point) -> 0.0,
         rectifier,
@@ -135,7 +135,7 @@ where ``V(x_0) = 0`` is enforced structurally, the equation will reduce to `0.0 
 which gets automatically removed in most cases.
 """
 function DontCheckNonnegativity(; check_fixed_point = true)::LyapunovMinimizationCondition
-    LyapunovMinimizationCondition(
+    return LyapunovMinimizationCondition(
         false,
         (state, fixed_point) -> 0.0,
         (t) -> zero(t),

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -48,7 +48,7 @@ function get_numerical_lyapunov_function(
         deriv = ForwardDiff.derivative,
         jac = ForwardDiff.jacobian,
         J_net = nothing
-)
+    )
     # network_func is the numerical form of neural network output
     network_func = phi_to_net(phi, θ)
 
@@ -58,7 +58,7 @@ function get_numerical_lyapunov_function(
         V(states::AbstractMatrix) = mapslices(V, states, dims = [1])
     end
 
-    if use_V̇_structure
+    return if use_V̇_structure
         # Make Jacobian of network_func
         network_jacobian = if isnothing(J_net)
             let net = network_func, J = jac
@@ -71,7 +71,7 @@ function get_numerical_lyapunov_function(
         end
 
         let _V = V, V̇_structure = structure.V̇, net = network_func, x0 = fixed_point,
-            f = dynamics, params = p, _J_net = network_jacobian
+                f = dynamics, params = p, _J_net = network_jacobian
 
             # Numerical time derivative of Lyapunov function
             V̇(state::AbstractVector) = V̇_structure(net, _J_net, f, state, params, 0.0, x0)
@@ -81,7 +81,7 @@ function get_numerical_lyapunov_function(
         end
     else
         let f_call = structure.f_call, _V = V, net = network_func, f = dynamics, params = p,
-            _deriv = deriv
+                _deriv = deriv
 
             # Numerical time derivative of Lyapunov function
             function V̇(state::AbstractVector)
@@ -124,7 +124,7 @@ end
 function phi_to_net(phi::Vector, θ; idx = eachindex(phi))
     let _θ = θ, φ = phi, _idx = idx
         return function (x)
-            reduce(
+            return reduce(
                 vcat,
                 Array(φ[i](x, _θ[Symbol(:φ, i)])) for i in _idx
             )

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -25,13 +25,13 @@ function add_policy_search(
         lyapunov_structure::NeuralLyapunovStructure,
         new_dims::Integer;
         control_structure = identity
-)::NeuralLyapunovStructure
-    let V = lyapunov_structure.V, V̇ = lyapunov_structure.V̇,
-        V_dim = lyapunov_structure.network_dim, u = control_structure
+    )::NeuralLyapunovStructure
+    return let V = lyapunov_structure.V, V̇ = lyapunov_structure.V̇,
+            V_dim = lyapunov_structure.network_dim, u = control_structure
 
         NeuralLyapunovStructure(
             function (net, state, fixed_point)
-                if length(size(state)) == 1
+                return if length(size(state)) == 1
                     if V_dim == 1
                         V(st -> net(st)[1], state, fixed_point)
                     else
@@ -42,9 +42,11 @@ function add_policy_search(
                 end
             end,
             function (net, J_net, f, state, params, t, fixed_point)
-                V̇(st -> net(st)[1:V_dim], st -> J_net(st)[1:V_dim, :],
+                return V̇(
+                    st -> net(st)[1:V_dim], st -> J_net(st)[1:V_dim, :],
                     (st, p, t) -> f(st, u(net(st)[(V_dim + 1):end]), p, t), state, params,
-                    t, fixed_point)
+                    t, fixed_point
+                )
             end,
             (f, net, state, p, t) -> f(state, u(net(state)[(V_dim + 1):end]), p, t),
             V_dim + new_dims
@@ -81,14 +83,14 @@ function get_policy(
         network_dim::Integer,
         control_dim::Integer;
         control_structure = identity
-)
+    )
     network_func = phi_to_net(phi, θ; idx = (network_dim - control_dim + 1):network_dim)
 
     function policy(state::AbstractVector)
-        control_structure(network_func(state))
+        return control_structure(network_func(state))
     end
     function policy(states::AbstractMatrix)
-        mapslices(
+        return mapslices(
             control_structure,
             network_func(states),
             dims = [1]

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -11,7 +11,7 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 """
 function NoAdditionalStructure()::NeuralLyapunovStructure
-    NeuralLyapunovStructure(
+    return NeuralLyapunovStructure(
         (net, x, x0) -> net(x),
         (net, grad_net, f, x, p, t, x0) -> grad_net(x) ⋅ f(x, p, t),
         (f, net, x, p, t) -> f(x, p, t),
@@ -59,8 +59,8 @@ function NonnegativeStructure(
         pos_def = (x, x0) -> log(1.0 + (x - x0) ⋅ (x - x0)),
         grad_pos_def = nothing,
         grad = ForwardDiff.gradient
-)::NeuralLyapunovStructure
-    if δ == 0.0
+    )::NeuralLyapunovStructure
+    return if δ == 0.0
         NeuralLyapunovStructure(
             (net, x, x0) -> net(x) ⋅ net(x),
             (net, J_net, f, x, p, t, x0) -> 2 * dot(net(x), J_net(x), f(x, p, t)),
@@ -76,7 +76,7 @@ function NonnegativeStructure(
         NeuralLyapunovStructure(
             (net, x, x0) -> net(x) ⋅ net(x) + δ * pos_def(x, x0),
             function (net, J_net, f, x, p, t, x0)
-                2 * dot(net(x), J_net(x), f(x, p, t)) + δ * grad_pos_def(x, x0) ⋅ f(x, p, t)
+                return 2 * dot(net(x), J_net(x), f(x, p, t)) + δ * grad_pos_def(x, x0) ⋅ f(x, p, t)
             end,
             (f, net, x, p, t) -> f(x, p, t),
             network_dim
@@ -132,7 +132,7 @@ function PositiveSemiDefiniteStructure(
         grad_pos_def = nothing,
         grad_non_neg = nothing,
         grad = ForwardDiff.gradient
-)::NeuralLyapunovStructure
+    )::NeuralLyapunovStructure
     _grad(f, x::AbstractArray{T}) where {T <: Num} = Symbolics.gradient(f(x), x)
     _grad(f, x) = grad(f, x)
     grad_pos_def = if isnothing(grad_pos_def)
@@ -145,7 +145,7 @@ function PositiveSemiDefiniteStructure(
     else
         grad_non_neg
     end
-    NeuralLyapunovStructure(
+    return NeuralLyapunovStructure(
         (net, x, x0) -> pos_def(x, x0) * non_neg(net, x, x0),
         function (net, J_net, f, x, p, t, x0)
             ẋ = f(x, p, t)

--- a/test/benchmark.jl
+++ b/test/benchmark.jl
@@ -37,7 +37,7 @@ using Test
     strategy = QuasiRandomTraining(1000)
 
     # Define neural Lyapunov structure and corresponding minimization condition
-    structure = NonnegativeStructure(dim_output; δ = 1e-6)
+    structure = NonnegativeStructure(dim_output; δ = 1.0e-6)
     minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 
     # Define Lyapunov decrease condition
@@ -90,8 +90,10 @@ end
         θ, ω = x
         ζ, ω_0 = p
         τ = u[]
-        return [ω
-                -2ζ * ω_0 * ω - ω_0^2 * sin(θ) + τ]
+        return [
+            ω
+            -2ζ * ω_0 * ω - ω_0^2 * sin(θ) + τ
+        ]
     end
 
     lb = [0.0, -2.0]
@@ -108,10 +110,12 @@ end
     dim_phi = 3
     dim_u = 1
     dim_output = dim_phi + dim_u
-    chain = [Chain(
-                 PeriodicEmbedding([1], Float32[2π]),
-                 MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-             ) for _ in 1:dim_output]
+    chain = [
+        Chain(
+                PeriodicEmbedding([1], Float32[2π]),
+                MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+            ) for _ in 1:dim_output
+    ]
     ps, st = Lux.setup(StableRNG(0), chain)
 
     # Define neural network discretization
@@ -147,7 +151,7 @@ end
     optimization_args = [[:maxiters => 300], [:maxiters => 300]]
 
     # Run benchmark
-    endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5e-3)
+    endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5.0e-3)
     classifier = (V, V̇, x) -> V̇ < zero(V̇) || endpoint_check(x)
     benchmarking_results = benchmark(
         open_loop_pendulum_dynamics,
@@ -220,7 +224,7 @@ end
     damped_pendulum = structural_simplify(damped_pendulum)
     bounds = [
         θ ∈ Float32.((-π, π)),
-        Dt(θ) ∈ (-10.0f0, 10.0f0)
+        Dt(θ) ∈ (-10.0f0, 10.0f0),
     ]
 
     # Define neural network discretization
@@ -228,10 +232,12 @@ end
     dim_state = length(bounds)
     dim_hidden = 15
     dim_output = 2
-    chain = [Chain(
-                 PeriodicEmbedding([1], Float32[2π]),
-                 MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-             ) for _ in 1:dim_output]
+    chain = [
+        Chain(
+                PeriodicEmbedding([1], Float32[2π]),
+                MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+            ) for _ in 1:dim_output
+    ]
 
     # Define neural network discretization
     strategy = QuadratureTraining()
@@ -273,7 +279,7 @@ end
         simulation_time = 300,
         n = 200,
         optimization_args,
-        endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, 1, 0], atol = 1e-3),
+        endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, 1, 0], atol = 1.0e-3),
         rng = StableRNG(0)
     )
     cm = out.confusion_matrix
@@ -300,7 +306,7 @@ end
     Dt = Differential(t)
     bounds = [
         θ ∈ (0, 2π),
-        Dt(θ) ∈ (-2.0, 2.0)
+        Dt(θ) ∈ (-2.0, 2.0),
     ]
 
     upright_equilibrium = [π, 0.0]
@@ -312,10 +318,12 @@ end
     dim_phi = 3
     dim_u = 1
     dim_output = dim_phi + dim_u
-    chain = [Chain(
-                 PeriodicEmbedding([1], [2π]),
-                 MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-             ) for _ in 1:dim_output]
+    chain = [
+        Chain(
+                PeriodicEmbedding([1], [2π]),
+                MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+            ) for _ in 1:dim_output
+    ]
     ps, st = Lux.setup(StableRNG(0), chain)
     ps = ps |> f64
     st = st |> f64
@@ -353,7 +361,7 @@ end
     optimization_args = [[:maxiters => 300], [:maxiters => 300]]
 
     # Run benchmark
-    endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5e-3)
+    endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5.0e-3)
     out = benchmark(
         driven_pendulum,
         bounds,

--- a/test/benchmark_CUDA.jl
+++ b/test/benchmark_CUDA.jl
@@ -122,7 +122,7 @@ end
     strategy = QuasiRandomTraining(1000)
 
     # Define neural Lyapunov structure and corresponding minimization condition
-    structure = NonnegativeStructure(dim_output; δ = 1e-6)
+    structure = NonnegativeStructure(dim_output; δ = 1.0e-6)
     minimization_condition = DontCheckNonnegativity(check_fixed_point = true)
 
     # Define Lyapunov decrease condition
@@ -266,7 +266,7 @@ end
     Dt = Differential(t)
     bounds = [
         θ ∈ Float32.((0, 2π)),
-        Dt(θ) ∈ (-2.0f0, 2.0f0)
+        Dt(θ) ∈ (-2.0f0, 2.0f0),
     ]
 
     upright_equilibrium = Float32[π, 0.0f0]
@@ -299,7 +299,7 @@ end
                 fixed_point_embedded,
                 [0.0f0]
             )
-        )
+        ),
     ]
     ps, st = Lux.setup(rng, chain)
     ps = ps .|> ComponentArray |> gpud |> f32
@@ -317,8 +317,8 @@ end
     # Define Lyapunov decrease condition
     decrease_condition = AsymptoticStability(
         strength = function (state, fixed_point)
-        return sum(abs2, periodic_embedding(state) .- periodic_embedding(fixed_point))
-    end
+            return sum(abs2, periodic_embedding(state) .- periodic_embedding(fixed_point))
+        end
     )
 
     # Construct neural Lyapunov specification

--- a/test/damped_pendulum.jl
+++ b/test/damped_pendulum.jl
@@ -28,7 +28,7 @@ eqs = [DDt(θ) + 2ζ * ω_0 * Dt(θ) + ω_0^2 * sin(θ) ~ 0.0]
 dynamics = structural_simplify(dynamics)
 bounds = [
     θ ∈ (-π, π),
-    Dt(θ) ∈ (-10.0, 10.0)
+    Dt(θ) ∈ (-10.0, 10.0),
 ]
 lb = [-π, -10.0];
 ub = [π, 10.0];
@@ -42,10 +42,12 @@ fixed_point = [0.0, 0.0]
 dim_state = length(bounds)
 dim_hidden = 15
 dim_output = 2
-chain = [Chain(
-             PeriodicEmbedding([1], [2π]),
-             MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-         ) for _ in 1:dim_output]
+chain = [
+    Chain(
+            PeriodicEmbedding([1], [2π]),
+            MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+        ) for _ in 1:dim_output
+]
 ps, st = Lux.setup(rng, chain)
 ps = ps |> ComponentArray |> f64
 st = st |> f64
@@ -121,7 +123,7 @@ dVdt_predict = vec(V̇(states))
 
 # Network structure should enforce periodicity in θ
 x0 = (ub .- lb) .* rand(rng, 2, 100) .+ lb
-@test maximum(abs, V(x0 .+ [2π, 0.0]) .- V(x0)) .≤ 1e-3
+@test maximum(abs, V(x0 .+ [2π, 0.0]) .- V(x0)) .≤ 1.0e-3
 
 # Check local negative definiteness at fixed point
 @test V̇(fixed_point) == 0.0
@@ -129,7 +131,7 @@ x0 = (ub .- lb) .* rand(rng, 2, 100) .+ lb
 @test maximum(eigvals(ForwardDiff.hessian(V̇, fixed_point))) ≤ 0
 
 # V̇ should be negative almost everywhere (global negative definiteness)
-@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 1e-3
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 1.0e-3
 
 #=
 # Print statistics

--- a/test/damped_pendulum_lux.jl
+++ b/test/damped_pendulum_lux.jl
@@ -102,20 +102,20 @@ V0 = V(fixed_point)[]
 @test min(V0, minimum(V_predict)) ≥ 0.0
 
 # Check local positive definiteness at fixed point
-@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1e-6
+@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1.0e-6
 @test minimum(eigvals(ForwardDiff.hessian(first ∘ V, fixed_point))) .≥ 0
 
 # Network structure should enforce periodicity in θ
 x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
-@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) .≤ 1e-3
+@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) .≤ 1.0e-3
 
 # Check local negative definiteness at fixed point
 @test V̇(fixed_point)[] == 0.0
-@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 2e-7
+@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 2.0e-7
 @test maximum(eigvals(ForwardDiff.hessian(first ∘ V̇, fixed_point))) ≤ 0
 
 # V̇ should be negative almost everywhere (global negative definiteness)
-@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 1e-3
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 1.0e-3
 
 #=
 # Print statistics

--- a/test/damped_pendulum_lux_2.jl
+++ b/test/damped_pendulum_lux_2.jl
@@ -101,20 +101,20 @@ V0 = V(fixed_point)[]
 @test min(V0, minimum(V_predict)) ≥ 0.0
 
 # Check local positive definiteness at fixed point
-@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1e-7
+@test maximum(abs, ForwardDiff.gradient(first ∘ V, fixed_point)) ≤ 1.0e-7
 @test minimum(eigvals(ForwardDiff.hessian(first ∘ V, fixed_point))) .≥ 0
 
 # Network structure should enforce periodicity in θ
 x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
-@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) .≤ 1e-3
+@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) .≤ 1.0e-3
 
 # Check local negative definiteness at fixed point
 @test V̇(fixed_point)[] == 0.0
-@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 1e-7
-@test maximum(eigvals(ForwardDiff.hessian(first ∘ V̇, fixed_point))) ≤ 1e-7
+@test maximum(abs, ForwardDiff.gradient(first ∘ V̇, fixed_point)) ≤ 1.0e-7
+@test maximum(eigvals(ForwardDiff.hessian(first ∘ V̇, fixed_point))) ≤ 1.0e-7
 
 # V̇ should be negative almost everywhere (global negative definiteness)
-@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 3e-3
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 3.0e-3
 
 #=
 # Print statistics

--- a/test/damped_sho.jl
+++ b/test/damped_sho.jl
@@ -108,7 +108,7 @@ end
 # @test maximum(eigvals(ForwardDiff.hessian(V̇, fixed_point))) ≤ 0.0
 
 # V̇ should be negative almost everywhere
-@test sum(V̇_samples .> 0) / length(V̇_samples) < 1e-3
+@test sum(V̇_samples .> 0) / length(V̇_samples) < 1.0e-3
 
 #=
 # Print statistics

--- a/test/damped_sho_CUDA.jl
+++ b/test/damped_sho_CUDA.jl
@@ -101,7 +101,7 @@ V_min, state_min = if V0 ≤ V_min
 else
     V_min, state_min
 end
-@test V_min ≥ -1e-2
+@test V_min ≥ -1.0e-2
 
 # Trained for V's minimum to be near the fixed point
 @test all(abs.(state_min .- fixed_point) .≤ 10 * [Δx, Δv])
@@ -112,7 +112,7 @@ end
 @test_broken maximum(eigvals(ForwardDiff.hessian(x -> (V̇(x) |> cpud)[], fixed_point))) ≤ 0
 
 # V̇ should be negative almost everywhere
-@test sum(V̇_samples .> 0) / length(V̇_samples) < 5e-3
+@test sum(V̇_samples .> 0) / length(V̇_samples) < 5.0e-3
 
 #=
 # Print statistics

--- a/test/inverted_pendulum.jl
+++ b/test/inverted_pendulum.jl
@@ -36,10 +36,12 @@ dim_hidden = 25
 dim_phi = 3
 dim_u = 1
 dim_output = dim_phi + dim_u
-chain = [Chain(
-             PeriodicEmbedding([1], Float32[2π]),
-             MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-         ) for _ in 1:dim_output]
+chain = [
+    Chain(
+            PeriodicEmbedding([1], Float32[2π]),
+            MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+        ) for _ in 1:dim_output
+]
 ps, st = Lux.setup(rng, chain)
 
 # Define neural network discretization
@@ -128,11 +130,11 @@ dVdt_predict = vec(V̇(states))
 
 # Network structure should enforce periodicity in θ
 x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
-@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) < 1e-3
+@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) < 1.0e-3
 
 # Training should result in a locally stable fixed point at the upright equilibrium
 # Check for approximately zero angular acceleration
-@test abs(closed_loop_pendulum_dynamics(upright_equilibrium)[2]) < 6e-3
+@test abs(closed_loop_pendulum_dynamics(upright_equilibrium)[2]) < 6.0e-3
 # Check for nonpositive eigenvalues of the Jacobian
 #=
 @test maximum(
@@ -144,11 +146,11 @@ x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
 
 # Check for local negative definiteness of V̇
 @test V̇(upright_equilibrium) == 0.0
-@test maximum(abs, ForwardDiff.gradient(V̇, upright_equilibrium)) < 5e-3
+@test maximum(abs, ForwardDiff.gradient(V̇, upright_equilibrium)) < 5.0e-3
 @test_broken maximum(eigvals(ForwardDiff.hessian(V̇, upright_equilibrium))) ≤ 0
 
 # V̇ should be negative almost everywhere
-@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 5e-3
+@test sum(dVdt_predict .> 0) / length(dVdt_predict) < 5.0e-3
 
 ################################## Simulate ###################################
 
@@ -168,7 +170,7 @@ sol = solve(ode_prob, Tsit5())
 # Should make it to the top
 θ_end, ω_end = sol.u[end]
 x_end, y_end = sin(θ_end), -cos(θ_end)
-@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5e-3
+@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5.0e-3
 
 # Starting at a random point
 x0 = lb .+ rand(rng, Float32, 2) .* (ub .- lb)
@@ -179,7 +181,7 @@ sol = solve(ode_prob, Tsit5())
 # Should make it to the top
 θ_end, ω_end = sol.u[end]
 x_end, y_end = sin(θ_end), -cos(θ_end)
-@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 4e-3
+@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 4.0e-3
 
 #=
 # Print statistics

--- a/test/inverted_pendulum_ODESystem.jl
+++ b/test/inverted_pendulum_ODESystem.jl
@@ -21,7 +21,7 @@ t, = independent_variables(driven_pendulum)
 Dt = Differential(t)
 bounds = [
     θ ∈ (0, 2π),
-    Dt(θ) ∈ (-2, 2)
+    Dt(θ) ∈ (-2, 2),
 ]
 
 upright_equilibrium = Float32[π, 0.0]
@@ -35,10 +35,12 @@ dim_hidden = 25
 dim_phi = 3
 dim_u = 1
 dim_output = dim_phi + dim_u
-chain = [Chain(
-             PeriodicEmbedding([1], Float32[2π]),
-             MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
-         ) for _ in 1:dim_output]
+chain = [
+    Chain(
+            PeriodicEmbedding([1], Float32[2π]),
+            MLP(dim_state + 1, (dim_hidden, dim_hidden, 1), tanh)
+        ) for _ in 1:dim_output
+]
 ps, st = Lux.setup(rng, chain)
 
 # Define neural network discretization
@@ -92,7 +94,8 @@ net = discretization.phi
 _θ = res.u.depvar
 
 (driven_pendulum_io, _) = structural_simplify(
-    driven_pendulum, ([τ], []); simplify = true, split = false)
+    driven_pendulum, ([τ], []); simplify = true, split = false
+)
 open_loop_pendulum_dynamics = ODEInputFunction(driven_pendulum_io)
 state_order = unknowns(driven_pendulum_io)
 
@@ -129,11 +132,11 @@ V̇_samples = vec(V̇(states))
 
 # Network structure should enforce periodicity in θ
 x0 = (ub .- lb) .* rand(rng, Float32, 2, 100) .+ lb
-@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) < 1e-3
+@test maximum(abs, V(x0 .+ Float32[2π, 0.0]) .- V(x0)) < 1.0e-3
 
 # Training should result in a locally stable fixed point at the upright equilibrium
 # Check for approximately zero angular acceleration
-@test abs(closed_loop_pendulum_dynamics(upright_equilibrium)[2]) < 3e-3
+@test abs(closed_loop_pendulum_dynamics(upright_equilibrium)[2]) < 3.0e-3
 # Check for nonpositive eigenvalues of the Jacobian
 #=
 @test maximum(
@@ -172,7 +175,7 @@ sol = solve(ode_prob, Tsit5())
 # ...the system should make it to the top
 θ_end, ω_end = sol.u[end]
 x_end, y_end = sin(θ_end), -cos(θ_end)
-@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5e-3
+@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5.0e-3
 
 # Starting at a random point ...
 x0 = lb .+ rand(rng, Float32, 2) .* (ub .- lb)
@@ -183,7 +186,7 @@ sol = solve(ode_prob, Tsit5())
 # ...the system should make it to the top
 θ_end, ω_end = sol.u[end]
 x_end, y_end = sin(θ_end), -cos(θ_end)
-@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5e-3
+@test maximum(abs, [x_end, y_end, ω_end] .- [0.0, 1.0, 0.0]) < 5.0e-3
 
 #=
 # Print statistics

--- a/test/local_lyapunov.jl
+++ b/test/local_lyapunov.jl
@@ -15,7 +15,7 @@ V1(x) = _V1(x) ./ _V1([0, 0, 1])
 xs1 = -1:0.1:1
 states1 = Iterators.map(collect, Iterators.product(xs1, xs1, xs1))
 errs1 = @. abs(V1(states1) - states1 ⋅ states1)
-@test all(errs1 .< 1e-10)
+@test all(errs1 .< 1.0e-10)
 
 ########################## Simple harmonic oscillator #########################
 function f2(state::AbstractVector, p, t)
@@ -38,7 +38,7 @@ dV2dt = (state) -> ForwardDiff.derivative(δt -> V2(state + δt * f2(state, p2, 
 xs2 = -1:0.03:1
 states2 = mapreduce(collect, hcat, Iterators.product(xs2, xs2))
 errs2 = abs.(V̇2(states2) .- dV2dt(states2))
-@test all(errs2 .< 1e-10)
+@test all(errs2 .< 1.0e-10)
 
 # Test V̇2 ≺ 0
 @test all(V̇2(states2) .< 0)

--- a/test/qa_tests.jl
+++ b/test/qa_tests.jl
@@ -18,7 +18,8 @@ end
     # We need a couple Symbolics internals (diff2term and value) and a ModelingToolkit
     # internal (unbound_inputs), and for some reason QuasiMonteCarlo doesn't export sample
     @test check_all_explicit_imports_are_public(
-        NeuralLyapunov; ignore = (:diff2term, :value, :sample, :unbound_inputs)) === nothing
+        NeuralLyapunov; ignore = (:diff2term, :value, :sample, :unbound_inputs)
+    ) === nothing
 
     # ForwardDiff doesn't export derivative, gradient, or jacobian, nor does SciMLBase with
     # NullParameters

--- a/test/unimplemented.jl
+++ b/test/unimplemented.jl
@@ -2,7 +2,7 @@ using NeuralLyapunov
 using Test
 
 struct UnimplementedMinimizationCondition <:
-       NeuralLyapunov.AbstractLyapunovMinimizationCondition end
+    NeuralLyapunov.AbstractLyapunovMinimizationCondition end
 
 cond = UnimplementedMinimizationCondition()
 


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)