### PR TITLE
Removes Julia nightly from CI tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,17 +22,14 @@ jobs:
       matrix:
         version:
           - '1.11'
-          - 'nightly'
+#          - 'lts' # LTS is 1.10, which isn't currently supported, but should eventually be
         project:
           - '.'
           - 'lib/NeuralLyapunovProblemLibrary'
         include:
           - os: ubuntu-latest
             arch: x64
-          - version: '1.11'
             allow_failure: false
-          - version: 'nightly'
-            allow_failure: true
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Also adds a note to add LTS to the CI tests at some point, but currently v1.10 isn't supported.