### PR TITLE
Reverts downgrade action to v1

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -24,9 +24,6 @@ jobs:
         project:
           - '.'
           - 'lib/NeuralLyapunovProblemLibrary'
-        downgrade_mode:
-          - alldeps
-          - forcedeps
         include:
           - version: '1.11'
             os: ubuntu-latest
@@ -37,12 +34,10 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
           projects: ${{ format('{0}, {0}/test', matrix.project) }}
           skip: LinearAlgebra, Pkg, Random, Test
-          julia_version: ${{ matrix.version }}
-          mode: ${{ matrix.downgrade_mode }}
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ matrix.project }}

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -45,8 +45,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           project: ${{ matrix.project }}
-          allow_reresolve: false
-          force_latest_compatible_version: false
         env:
-          GROUP: "all"
+          GROUP: "ci"
   


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

`julia-downgrade-compat@v2` is failing and appears to be under some maintenance still, so we're reverting back to v1 for now.