### PR TITLE
Split in-RoA-penalty and out-of-RoA-penalty in `RoAAwareDecreaseCondition` into separate decrease equations in `NeuralLyapunovPDESystem`

### DIFF
--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -280,12 +280,28 @@ function _NeuralLyapunovPDESystem(
 
     if check_nonnegativity(minimization_condition)
         cond = get_minimization_condition(minimization_condition)::Function
-        push!(eqs, cond(V, state, fixed_point) ~ 0.0)
+        cond_eq = cond(V, state, fixed_point) .~ 0.0
+        if cond_eq isa Equation
+            push!(eqs, cond_eq)
+        elseif cond_eq isa AbstractVector{Equation}
+            append!(eqs, cond_eq)
+        else
+            error("Minimization condition function must return an Equation or vector of ",
+                "Equations. Instead got $(typeof(cond_eq)).")
+        end
     end
 
     if check_decrease(decrease_condition)
         cond = get_decrease_condition(decrease_condition)::Function
-        push!(eqs, cond(V, V̇, state, fixed_point) ~ 0.0)
+        cond_eq = cond(V, V̇, state, fixed_point) .~ 0.0
+        if cond_eq isa Equation
+            push!(eqs, cond_eq)
+        elseif cond_eq isa AbstractVector{Equation}
+            append!(eqs, cond_eq)
+        else
+            error("Decrease condition function must return an Equation or vector of ",
+                "Equations. Instead got $(typeof(cond_eq)).")
+        end
     end
 
     bcs = Equation[]

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -286,8 +286,10 @@ function _NeuralLyapunovPDESystem(
         elseif cond_eq isa AbstractVector{Equation}
             append!(eqs, cond_eq)
         else
-            error("Minimization condition function must return an Equation or vector of ",
-                "Equations. Instead got $(typeof(cond_eq)).")
+            error(
+                "Minimization condition function must return an Equation or vector of ",
+                "Equations. Instead got $(typeof(cond_eq))."
+            )
         end
     end
 
@@ -299,8 +301,10 @@ function _NeuralLyapunovPDESystem(
         elseif cond_eq isa AbstractVector{Equation}
             append!(eqs, cond_eq)
         else
-            error("Decrease condition function must return an Equation or vector of ",
-                "Equations. Instead got $(typeof(cond_eq)).")
+            error(
+                "Decrease condition function must return an Equation or vector of ",
+                "Equations. Instead got $(typeof(cond_eq))."
+            )
         end
     end
 

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -178,6 +178,10 @@ and is greater than zero if it's violated.
 
 Note that the first input, ``V``, is a function, so the minimization condition can depend on
 the value of the candidate Lyapunov function at multiple points.
+
+If the returned function returns a vector, all elements of the vector must be zero for the
+condition to be considered met.
+[`NeuralLyapunovPDESystem`](@ref) will create one equation per element of the vector.
 """
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
     error(
@@ -225,6 +229,10 @@ decrease condition is met and a value greater than zero when it is violated.
 
 Note that the first two inputs, ``V`` and ``V̇``, are functions, so the decrease condition
 can depend on the value of these functions at multiple points.
+
+If the returned function returns a vector, all elements of the vector must be zero for the
+condition to be considered met.
+[`NeuralLyapunovPDESystem`](@ref) will create one equation per element of the vector.
 """
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
     error(

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -19,10 +19,14 @@ Inside the region of attraction (i.e., when ``V(x) ≤ ρ``), the loss function 
 `cond` will be applied. Outside the region of attraction (i.e., when ``V(x) > ρ``), the loss
 function specified by `out_of_RoA_penalty` will be applied.
 
-The `sigmoid` function allows for a smooth transition between the ``V(x) ≤ ρ`` case and the
-``V(x) > ρ`` case, by combining the different losses into one:
+The `sigmoid` function smoothly turns off the in-RoA loss and turns on the out-of-RoA loss
+as the value of ``V(x)`` crosses the threshold ``ρ``, resulting in the dual loss equations:
 
-``\\texttt{sigmoid}(ρ - V(x)) (\\text{in-RoA expression}) + \\texttt{sigmoid}(V(x) - ρ) (\\text{out-of-RoA expression}) = 0``.
+``\\texttt{sigmoid}(ρ - V(x)) (\\text{in-RoA expression}) = 0``
+
+and
+
+``\\texttt{sigmoid}(V(x) - ρ) (\\text{out-of-RoA expression}) = 0``.
 
 Note that a hard transition, which only enforces the in-RoA equation when ``V(x) ≤ ρ`` and
 the out-of-RoA equation when ``V(x) > ρ`` can be provided by a `sigmoid` which is exactly
@@ -105,9 +109,11 @@ function get_decrease_condition(cond::RoAAwareDecreaseCondition)
             _V = _V isa AbstractVector ? _V[] : _V
             _V̇ = dVdt(x)
             _V̇ = _V̇ isa AbstractVector ? _V̇[] : _V̇
-            return cond.sigmoid(cond.ρ - _V) * in_RoA_penalty(V, dVdt, x, fixed_point) +
+            return [
+                cond.sigmoid(cond.ρ - _V) * in_RoA_penalty(V, dVdt, x, fixed_point),
                 cond.sigmoid(_V - cond.ρ) *
                 cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ)
+            ]
         end
     else
         return nothing
@@ -139,10 +145,14 @@ by `cond` only in that sublevel set.
 The loss applied to samples ``x`` such that ``V(x) > ρ`` is
 ``\\lvert \\texttt{out\\_of\\_RoA\\_penalty}(V(x), V̇(x), x, x_0, ρ) \\rvert^2``.
 
-The `sigmoid` function allows for a smooth transition between the ``V(x) ≤ ρ`` case and the
-``V(x) > ρ`` case, by combining the above equations into one:
+The `sigmoid` function smoothly turns off the in-RoA loss and turns on the out-of-RoA loss
+as the value of ``V(x)`` crosses the threshold ``ρ``, resulting in the dual loss equations:
 
-``\\texttt{sigmoid}(ρ - V(x)) (\\text{in-RoA expression}) + \\texttt{sigmoid}(V(x) - ρ) (\\text{out-of-RoA expression}) = 0``.
+``\\texttt{sigmoid}(ρ - V(x)) (\\text{in-RoA expression}) = 0``
+
+and
+
+``\\texttt{sigmoid}(V(x) - ρ) (\\text{out-of-RoA expression}) = 0``.
 
 Note that a hard transition, which only enforces the in-RoA equation when ``V(x) ≤ ρ`` and
 the out-of-RoA equation when ``V(x) > ρ`` can be provided by a `sigmoid` which is exactly

--- a/src/decrease_conditions_RoA_aware.jl
+++ b/src/decrease_conditions_RoA_aware.jl
@@ -112,7 +112,7 @@ function get_decrease_condition(cond::RoAAwareDecreaseCondition)
             return [
                 cond.sigmoid(cond.ρ - _V) * in_RoA_penalty(V, dVdt, x, fixed_point),
                 cond.sigmoid(_V - cond.ρ) *
-                cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ)
+                    cond.out_of_RoA_penalty(_V, _V̇, x, fixed_point, cond.ρ),
             ]
         end
     else


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This will allow for adaptive reweighting in training, so the two penalties will no longer need to be on the same scale.