### PR TITLE
Reverts NeuralLyapunovProblemLibrary to MTK 10

### DIFF
--- a/lib/NeuralLyapunovProblemLibrary/Project.toml
+++ b/lib/NeuralLyapunovProblemLibrary/Project.toml
@@ -18,9 +18,9 @@ NeuralLyapunovProblemLibraryPlotsExt = "Plots"
 
 [compat]
 LinearAlgebra = "1"
-ModelingToolkit = "10, 11"
+ModelingToolkit = "10"
 Plots = "1.40.9"
 Rotations = "1.7.1"
 SciMLBase = "2.91.1"
-Symbolics = "6.40, 7"
+Symbolics = "6.40"
 julia = "1.11"

--- a/lib/NeuralLyapunovProblemLibrary/test/double_pendulum_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/double_pendulum_test.jl
@@ -78,7 +78,16 @@ anim = plot_double_pendulum(sol, p)
 ########################### Feedback cancellation, PD controller ###########################
 println("Double pendulum feedback cancellation test")
 
-@named double_pendulum = DoublePendulum()
+# Assume uniform rods of random mass and length
+m1, m2 = ones(2)
+l1, l2 = ones(2)
+lc1, lc2 = l1 / 2, l2 / 2
+I1 = m1 * l1^2 / 3
+I2 = m2 * l2^2 / 3
+g = 1.0
+p = [I1, I2, l1, l2, lc1, lc2, m1, m2, g]
+
+@named double_pendulum = DoublePendulum(defaults = p)
 
 function π_cancellation(x, p, t)
     θ1, θ2, ω1, ω2 = x
@@ -97,22 +106,10 @@ end
 @mtkcompile double_pendulum_feedback_cancellation = control_double_pendulum(double_pendulum, π_cancellation)
 
 # Swing up to upward equilibrium
-# Assume uniform rods of random mass and length
-m1, m2 = ones(2)
-l1, l2 = ones(2)
-lc1, lc2 = l1 / 2, l2 / 2
-I1 = m1 * l1^2 / 3
-I2 = m2 * l2^2 / 3
-g = 1.0
-p = [I1, I2, l1, l2, lc1, lc2, m1, m2, g]
-
-params = get_double_pendulum_param_symbols(double_pendulum)
-p_dict = Dict(params .=> p)
 x = get_double_pendulum_state_symbols(double_pendulum)
 x0 = Dict(x .=> vcat(2π * rand(rng, 2) .- π, rand(rng, 2)))
 
-op = merge(x0, p_dict)
-prob = ODEProblem(double_pendulum_feedback_cancellation, op, 100)
+prob = ODEProblem(double_pendulum_feedback_cancellation, x0, 100)
 sol = solve(prob, Tsit5())
 
 θ1 = double_pendulum.θ1

--- a/lib/NeuralLyapunovProblemLibrary/test/pendulum_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/pendulum_test.jl
@@ -37,7 +37,11 @@ anim = plot_pendulum(sol)
 ############################# Feedback cancellation controller #############################
 println("Simple pendulum feedback cancellation test")
 
-@named pendulum_driven = Pendulum()
+x0 = rand(rng, 2)
+p = rand(rng, 2)
+τ = 1 / prod(p)
+
+@named pendulum_driven = Pendulum(defaults = p)
 
 π_cancellation(x, p, t) = 2 * p[2]^2 * sin(x[1])
 
@@ -46,16 +50,8 @@ println("Simple pendulum feedback cancellation test")
 pendulum_feedback_cancellation = mtkcompile(pendulum_feedback_cancellation)
 
 # Swing up to upward equilibrium
-x0 = rand(rng, 2)
-p = rand(rng, 2)
-τ = 1 / prod(p)
+op = Dict(get_pendulum_state_symbols(pendulum_driven) .=> x0)
 
-op = Dict(
-    vcat(
-        get_pendulum_state_symbols(pendulum_driven),
-        get_pendulum_param_symbols(pendulum_driven)
-    ) .=> vcat(x0, p)
-)
 prob = ODEProblem(pendulum_feedback_cancellation, op, 15τ)
 sol = solve(prob, Tsit5())
 

--- a/lib/NeuralLyapunovProblemLibrary/test/planar_quadrotor_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/planar_quadrotor_test.jl
@@ -93,24 +93,22 @@ function π_lqr(p; x_eq = zeros(6), Q = I(6), R = I(2))
     return (x, _p, _t) -> -L * (x - x_eq) + [T0, T0]
 end
 
-@named quadrotor_planar = QuadrotorPlanar()
-
 # Assume rotors are negligible mass when calculating the moment of inertia
 m, r = ones(2)
 g = 1.0
 I_quad = m * r^2 / 12
 p = [m, I_quad, g, r]
 
+@named quadrotor_planar = QuadrotorPlanar(defaults = p)
+
 @mtkcompile quadrotor_planar_lqr = control_quadrotor_planar(quadrotor_planar, π_lqr(p))
 
 # Fly to origin
 x = get_quadrotor_planar_state_symbols(quadrotor_planar)
 x0 = Dict(x .=> 2 * rand(rng, 6) .- 1)
-p_dict = Dict(get_quadrotor_planar_param_symbols(quadrotor_planar) .=> p)
 τ = sqrt(r / g)
 
-op = merge(x0, p_dict)
-prob = ODEProblem(quadrotor_planar_lqr, op, 15τ)
+prob = ODEProblem(quadrotor_planar_lqr, x0, 15τ)
 sol = solve(prob, Tsit5())
 
 q = x[1:3]

--- a/lib/NeuralLyapunovProblemLibrary/test/quadrotor_test.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/quadrotor_test.jl
@@ -124,8 +124,6 @@ function π_lqr(p; x_eq = zeros(12), u_eq = [p[1] * p[2], 0, 0, 0], Q = I(12), R
     return (x, _p, _t) -> -L * (x - x_eq) + u_eq
 end
 
-@named quadrotor_3d = Quadrotor3D()
-
 # Assume rotors are negligible mass when calculating the moment of inertia
 m, L = ones(2)
 g = 1.0
@@ -134,17 +132,17 @@ Izz = m * L^2 / 3
 Ixy = Ixz = Iyz = 0.0
 p = [m, g, Ixx, Ixy, Ixz, Iyy, Iyz, Izz]
 
+@named quadrotor_3d = Quadrotor3D(defaults = p)
+
 @mtkcompile quadrotor_3d_lqr = control_quadrotor_3d(quadrotor_3d, π_lqr(p))
 
 # Fly to origin
 δ = 0.5
 x = get_quadrotor_3d_state_symbols(quadrotor_3d)
 x0 = Dict(x .=> δ .* (2 .* rand(rng, 12) .- 1))
-p_dict = Dict(get_quadrotor_3d_param_symbols(quadrotor_3d) .=> p)
 τ = sqrt(L / g)
 
-op = merge(x0, p_dict)
-prob = ODEProblem(quadrotor_3d_lqr, op, 15τ)
+prob = ODEProblem(quadrotor_3d_lqr, x0, 15τ)
 sol = solve(prob, Tsit5())
 
 q = x[1:6]


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

MTK 11 replaced `defaults` with `initial_conditions` and that was not adequately accounted for in #135. This PR reverts back to MTK 10 and adds tests that should have failed with MTK 11.
