### PR TITLE
Split CI tests up by group

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,7 @@ steps:
       cuda: "*"
     env:
       DEVICE: 'GPU'
-      GROUP: 'CI'
+      GROUP: 'ALL'
       JULIA_PKG_SERVER: "" # it often struggles with our large artifacts
       # SECRET_CODECOV_TOKEN: "..."
     timeout_in_minutes: 1440

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   tests:
-    name: NeuralLyapunov Tests
+    name: NeuralLyapunov
     concurrency:
       # Skip intermediate builds: always.
       # Cancel intermediate builds: only if it is a pull request build.
@@ -41,7 +41,7 @@ jobs:
       group: ${{ matrix.group }}
     secrets: "inherit"
   library-tests:
-    name: NeuralLyapunovProblemLibrary Tests
+    name: NeuralLyapunovProblemLibrary
     concurrency:
       # Skip intermediate builds: always.
       # Cancel intermediate builds: only if it is a pull request build.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,12 +23,13 @@ jobs:
         version:
           - '1.11'
 #          - 'lts' # LTS is 1.10, which isn't currently supported, but should eventually be
+        project:
+          - '.'
+          - 'lib/NeuralLyapunovProblemLibrary'
         include:
           - os: ubuntu-latest
             arch: x64
             allow_failure: false
-          - project: '.'
-            group: 'core'
           - project: '.'
             group: 'core'
           - project: '.'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,44 +8,59 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
 jobs:
   tests:
-    name: Tests
+    name: NeuralLyapunov Tests
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only if it is a pull request build.
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.project }}-${{matrix.group}}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     strategy:
       fail-fast: false
       matrix:
         version:
           - '1.11'
 #          - 'lts' # LTS is 1.10, which isn't currently supported, but should eventually be
-        project:
-          - '.'
-          - 'lib/NeuralLyapunovProblemLibrary'
+        group:
+          - 'core'
+          - 'policy_search'
+          - 'roa'
+          - 'local_lyapunov'
+          - 'benchmarking'
+          - 'unimplemented'
         include:
-          - os: ubuntu-latest
+          - project: '.'
+            os: ubuntu-latest
             arch: x64
             allow_failure: false
-          - project: '.'
-            group: 'core'
-          - project: '.'
-            group: 'policy_search'
-          - project: '.'
-            group: 'roa'
-          - project: '.'
-            group: 'local_lyapunov'
-          - project: '.'
-            group: 'benchmarking'
-          - project: '.'
-            group: 'unimplemented'
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "${{ matrix.version }}"
+      project: "${{ matrix.project }}"
+      group: ${{ matrix.group }}
+    secrets: "inherit"
+  library-tests:
+    name: NeuralLyapunovProblemLibrary Tests
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only if it is a pull request build.
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.project }}-${{matrix.group}}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.11'
+#          - 'lts' # LTS is 1.10, which isn't currently supported, but should eventually be
+        group:
+          - 'pendula'
+          - 'quadrotors'
+        include:
           - project: 'lib/NeuralLyapunovProblemLibrary'
-            group: 'pendula'
-          - project: 'lib/NeuralLyapunovProblemLibrary'
-            group: 'quadrotors'
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: false
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,16 +23,31 @@ jobs:
         version:
           - '1.11'
 #          - 'lts' # LTS is 1.10, which isn't currently supported, but should eventually be
-        project:
-          - '.'
-          - 'lib/NeuralLyapunovProblemLibrary'
         include:
           - os: ubuntu-latest
             arch: x64
             allow_failure: false
+          - project: '.'
+            group: 'core'
+          - project: '.'
+            group: 'core'
+          - project: '.'
+            group: 'policy_search'
+          - project: '.'
+            group: 'roa'
+          - project: '.'
+            group: 'local_lyapunov'
+          - project: '.'
+            group: 'benchmarking'
+          - project: '.'
+            group: 'unimplemented'
+          - project: 'lib/NeuralLyapunovProblemLibrary'
+            group: 'pendula'
+          - project: 'lib/NeuralLyapunovProblemLibrary'
+            group: 'quadrotors'
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       julia-version: "${{ matrix.version }}"
       project: "${{ matrix.project }}"
-      group: "ci"
+      group: ${{ matrix.group }}
     secrets: "inherit"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   downgrade:
-    name: NeuralLyapunov Downgrade
+    name: NeuralLyapunov
     concurrency:
       # Skip intermediate builds: always.
       # Cancel intermediate builds: only if it is a pull request build.
@@ -65,7 +65,7 @@ jobs:
           skip: LinearAlgebra, Pkg, Random, Test
           julia_version: ${{ matrix.version }}
   library-downgrade:
-    name: NeuralLyapunovProblemLibrary Downgrade
+    name: NeuralLyapunovProblemLibrary
     concurrency:
       # Skip intermediate builds: always.
       # Cancel intermediate builds: only if it is a pull request build.

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -8,24 +8,28 @@ on:
   pull_request:
   workflow_dispatch:
 
-concurrency:
-  # Skip intermediate builds: always.
-  # Cancel intermediate builds: only if it is a pull request build.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-
 jobs:
   downgrade:
-    name: Downgrade
+    name: NeuralLyapunov Downgrade
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only if it is a pull request build.
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.project }}-${{matrix.group}}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        project:
-          - '.'
-          - 'lib/NeuralLyapunovProblemLibrary'
+        group:
+          - 'core'
+          - 'policy_search'
+          - 'roa'
+          - 'local_lyapunov'
+          - 'benchmarking'
+          - 'unimplemented'
         include:
-          - version: '1.11'
+          - project: '.'
+            version: '1.11'
             os: ubuntu-latest
             arch: x64
             allow_failure: false
@@ -49,7 +53,58 @@ jobs:
         with:
           project: ${{ matrix.project }}
         env:
-          GROUP: "ci"
+          GROUP: ${{ matrix.group }}
+      # On a failed build, use julia-downgrade-compat to resolve a list of compatibility issues.
+      - if: ${{ always() && steps.buildpkg.outcome == 'failure' }}
+        uses: actions/checkout@v6
+      - if: ${{ always() && steps.buildpkg.outcome == 'failure' }}
+        uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          mode: forcedeps
+          projects: ${{ format('{0}, {0}/test', matrix.project) }}
+          skip: LinearAlgebra, Pkg, Random, Test
+          julia_version: ${{ matrix.version }}
+  library-downgrade:
+    name: NeuralLyapunovProblemLibrary Downgrade
+    concurrency:
+      # Skip intermediate builds: always.
+      # Cancel intermediate builds: only if it is a pull request build.
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.project }}-${{matrix.group}}
+      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - 'pendula'
+          - 'quadrotors'
+        include:
+          - project: 'lib/NeuralLyapunovProblemLibrary'
+            version: '1.11'
+            os: ubuntu-latest
+            arch: x64
+            allow_failure: false
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.version }}
+      - uses: julia-actions/julia-downgrade-compat@v1
+        with:
+          projects: ${{ format('{0}, {0}/test', matrix.project) }}
+          skip: LinearAlgebra, Pkg, Random, Test
+      - id: buildpkg
+        uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: ${{ matrix.project }}
+          precompile: yes
+      # On a successful build, check that the usual CI tests pass.
+      - if: ${{ steps.buildpkg.outcome == 'success' }}
+        uses: julia-actions/julia-runtest@v1
+        with:
+          project: ${{ matrix.project }}
+        env:
+          GROUP: ${{ matrix.group }}
       # On a failed build, use julia-downgrade-compat to resolve a list of compatibility issues.
       - if: ${{ always() && steps.buildpkg.outcome == 'failure' }}
         uses: actions/checkout@v6

--- a/.github/workflows/QualityCheck.yml
+++ b/.github/workflows/QualityCheck.yml
@@ -1,6 +1,12 @@
 name: Code Quality Check
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - master
+    tags: ['*']
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   typos-check:

--- a/lib/NeuralLyapunovProblemLibrary/test/runtests.jl
+++ b/lib/NeuralLyapunovProblemLibrary/test/runtests.jl
@@ -3,7 +3,7 @@ using SafeTestsets: @safetestset
 const GROUP = lowercase(get(ENV, "GROUP", "all"))
 
 @time begin
-    if GROUP == "all" || GROUP == "ci" || GROUP == "pendula"
+    if GROUP == "all" || GROUP == "pendula"
         @time @safetestset "Simple pendulum" begin
             include("pendulum_test.jl")
         end
@@ -13,7 +13,7 @@ const GROUP = lowercase(get(ENV, "GROUP", "all"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "quadrotors"
+    if GROUP == "all" || GROUP == "quadrotors"
         @time @safetestset "Planar Quadrotor" begin
             include("planar_quadrotor_test.jl")
         end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,7 @@ const GROUP = lowercase(get(ENV, "GROUP", "all"))
 const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
 
 @time begin
-    if GROUP == "all" || GROUP == "ci" || GROUP == "core"
+    if GROUP == "all" || GROUP == "core"
         if DEVICE == "cpu"
             @time @safetestset "Damped simple harmonic oscillator" begin
                 include("damped_sho.jl")
@@ -27,7 +27,7 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "policy_search"
+    if GROUP == "all" || GROUP == "policy_search"
         if DEVICE == "cpu"
             @time @safetestset "Policy search - inverted pendulum" begin
                 include("inverted_pendulum.jl")
@@ -38,7 +38,7 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "roa"
+    if GROUP == "all" || GROUP == "roa"
         if DEVICE == "cpu"
             @time @safetestset "Region of attraction estimation" begin
                 include("roa_estimation.jl")
@@ -46,7 +46,7 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "local_lyapunov"
+    if GROUP == "all" || GROUP == "local_lyapunov"
         if DEVICE == "cpu"
             @time @safetestset "Local Lyapunov function search" begin
                 include("local_lyapunov.jl")
@@ -54,7 +54,7 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "benchmarking"
+    if GROUP == "all" || GROUP == "benchmarking"
         if DEVICE == "cpu"
             @time @safetestset "Benchmarking tool" begin
                 include("benchmark.jl")
@@ -67,7 +67,7 @@ const DEVICE = lowercase(get(ENV, "DEVICE", "cpu"))
         end
     end
 
-    if GROUP == "all" || GROUP == "ci" || GROUP == "unimplemented"
+    if GROUP == "all" || GROUP == "unimplemented"
         if DEVICE == "cpu"
             @time @safetestset "Errors for partially-implemented extensions" begin
                 include("unimplemented.jl")


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Should speed up CI runs by allowing test groups to run in parallel in separate runs. This also means that if an early test fails, we still see what other tests are passing/failing.

Additionally modifies QualityCheck workflow to have same triggers as CI and Downgrade.
