### PR TITLE
Add benchmarking.md to the documentation list

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,6 +31,7 @@ MANUAL_PAGES = [
     "man/structure.md",
     "man/roa.md",
     "man/policy_search.md",
+    "man/benchmarking.md",
     "man/local_lyapunov.md",
 ]
 DEMONSTRATION_PAGES = [


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

It appears that the benchmarking.md page was never added to the documentation table of contents.