### PR TITLE
Simplify root CI to grouped-tests.yml (matrix from test/test_groups.toml)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,65 +8,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   tests:
-    name: NeuralLyapunov
-    concurrency:
-      # Skip intermediate builds: always.
-      # Cancel intermediate builds: only if it is a pull request build.
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.project }}-${{matrix.group}}-${{ matrix.version }}
-      cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          # NeuralLyapunov supports julia >= 1.11; lts (1.10) is intentionally
-          # omitted (below the compat floor), so 1.11 fills the canonical lts slot.
-          - '1.11'
-          - '1'
-          - 'pre'
-        group:
-          - 'Core'
-          - 'Policy_search'
-          - 'ROA'
-          - 'Local_lyapunov'
-          - 'Benchmarking'
-          - 'Unimplemented'
-          - 'QA'
-          - 'Doctests'
-        exclude:
-          # QA and Doctests are dep-adding groups declared on [1.11, 1] in
-          # test/test_groups.toml; they do not run on 'pre'.
-          - group: 'QA'
-            version: 'pre'
-          - group: 'Doctests'
-            version: 'pre'
-        include:
-          - project: '.'
-            os: ubuntu-latest
-            arch: x64
-            allow_failure: false
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "${{ matrix.version }}"
-      project: "${{ matrix.project }}"
-      group: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
     secrets: "inherit"
-
-  # GPU tests are a dep-adding group (test/gpu/Project.toml) declared on [1] in
-  # test/test_groups.toml; it runs on the self-hosted GPU runner. Folded in from
-  # the former bespoke GPU.yml.
-  gpu:
-    name: "GPU Tests"
-    uses: "SciML/.github/.github/workflows/tests.yml@v1"
-    with:
-      julia-version: "1"
-      project: "."
-      group: "GPU"
-      runner: '["self-hosted", "Linux", "X64", "gpu"]'
-      timeout-minutes: 360
-    secrets: "inherit"
-  # lib/NeuralLyapunovProblemLibrary is tested by SublibraryCI.yml (project model),
-  # which expands the sublibrary's test/test_groups.toml (Pendula, Quadrotors,
-  # Doctests, QA) across its declared versions, so it is intentionally not
-  # duplicated as a root CI matrix job.

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -3,8 +3,10 @@
 # compat floor). Base groups run on [lts->1.11, 1, pre] in the main test env and
 # are part of the `All` run. QA and Doctests are the canonical [lts->1.11, 1]
 # groups; QA, Doctests, and GPU carry their own test/<group>/Project.toml and run
-# only when selected (excluded from `All`). The root CI.yml matrix realizes every
-# group below at exactly these versions, so this file and CI agree.
+# only when selected (excluded from `All`). This file is the single source of
+# truth for the root CI matrix: CI.yml is a thin caller of
+# grouped-tests.yml@v1, which expands the groups below via
+# scripts/compute_affected_sublibraries.jl --root-matrix.
 [Core]
 versions = ["1.11", "1", "pre"]
 
@@ -32,4 +34,4 @@ versions = ["1.11", "1"]
 [GPU]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
-timeout = 60
+timeout = 360


### PR DESCRIPTION
## What

Converts the root test workflow (`.github/workflows/CI.yml`, `name: CI`) from a hand-maintained `group × version` matrix calling `tests.yml@v1` (plus a separate folded-in `gpu` job) into a thin caller of the centralized `grouped-tests.yml@v1`. The full matrix now lives in `test/test_groups.toml` and is expanded by `scripts/compute_affected_sublibraries.jl --root-matrix`.

`SublibraryCI.yml` (the project-model sublibrary CI calling `sublibrary-project-tests.yml@v1`) is intentionally left untouched.

## New caller

```yaml
jobs:
  tests:
    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
    secrets: "inherit"
```

No `with:` inputs are needed:
- The root `test/runtests.jl` dispatches on the default `GROUP` env var, so no `group-env-name` override.
- The old root job used only `tests.yml@v1` defaults (`check-bounds: yes`, `coverage: true`, `coverage-directories: src,ext`), all of which match `grouped-tests.yml`'s defaults.

The workflow `name: CI`, its `on:` triggers, and concurrency are preserved (the matrix-scoped per-job `concurrency` is lifted to a top-level `concurrency` keyed on `github.workflow`/`github.ref`, since the matrix vars it referenced no longer exist).

## test_groups.toml change

The file already declared every group at the correct versions. The only edit: bump the `GPU` group `timeout` from `60` to `360` to match the former `gpu` job's `timeout-minutes: 360`, so the reproduced matrix is exact.

## Verified matrix match: 23/23 exact

Ran `scripts/compute_affected_sublibraries.jl <repo> --root-matrix` and compared the emitted `(group, version)` set against the old workflow (tests job after applying its `exclude:`, plus the `gpu` job):

- Core, Policy_search, ROA, Local_lyapunov, Benchmarking, Unimplemented × [1.11, 1, pre] = 18
- QA, Doctests × [1.11, 1] (pre excluded) = 4
- GPU × [1] on `["self-hosted","Linux","X64","gpu"]`, timeout 360 = 1

Total: **23/23, no missing, no extra**. GPU runner/timeout and all base-group `ubuntu-latest` runners confirmed. TOML and YAML parse-checked. Package test suite not run locally (heavy; CI validates).

---

Ignore until reviewed by @ChrisRackauckas.