### PR TITLE
Fix downgrade CI config (julia_floor)

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -23,6 +23,6 @@ jobs:
           - 'Unimplemented'
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
     with:
-      julia-version: "lts"
+      julia-version: "1.11"
       group: "${{ matrix.group }}"
     secrets: "inherit"


### PR DESCRIPTION
## Problem

The `Downgrade` workflow has been failing on `master` since 2026-06-08. The exact first error (from the master run, group Benchmarking):

```
ERROR: LoadError: Unsatisfiable requirements detected for package NeuralLyapunovProblemLibrary [83723521]:
 NeuralLyapunovProblemLibrary [83723521] log:
 ├─possible versions are: 0.0.1-0.2.2 or uninstalled
 ├─restricted to versions 0.2.2-0.2 by project [53b524b3], leaving only versions: 0.2.2
 └─restricted by julia compatibility requirements to versions: uninstalled — no versions left
```

CI ran on **Julia 1.10.11** (`julia-version: "lts"` resolves to 1.10), but:

- The package's `[compat] julia` floor is `"1.11"`.
- The test dependency `NeuralLyapunovProblemLibrary` (only available registered version 0.2.2, used here via the `[sources]` path-dep) also has `[compat] julia = "1.11"`.

Resolving the test environment on Julia 1.10 therefore leaves no installable version of `NeuralLyapunovProblemLibrary`, producing the unsatisfiable error above. This is a CI-config / Julia-floor mismatch, **not** a package version conflict.

## Root cause (introduced, not pre-existing)

The Downgrade workflow was **green on master through 2026-06-07** and flipped to failure on 2026-06-08. PR #190 ("Uniformize monorepo structure") changed the caller's `julia-version` from `"1.11"` to `"lts"` while the package floor stayed at `1.11`:

```diff
-      julia-version: "1.11"
+      julia-version: "lts"
```

## Fix

Restore `julia-version: "1.11"` in `.github/workflows/Downgrade.yml` so the downgrade run uses a Julia version that satisfies the package's `1.11` floor. Config-only change; no `Project.toml` compat, test, or source files were touched.

Verified: `actionlint` passes clean, and `1.11` is a valid setup-julia channel that satisfies the `julia = "1.11"` floor.

(Note: the separate `Downgrade Sublibraries` workflow is currently green on master — it uses a merged-project downgrade that strips the julia floor — so it is left unchanged.)

Ignore until reviewed by @ChrisRackauckas.