### PR TITLE
Rework how dynamics and controls interact with structure

### DIFF
--- a/docs/src/demos/benchmarking.md
+++ b/docs/src/demos/benchmarking.md
@@ -76,7 +76,7 @@ opt = OptimizationOptimisers.Adam(0.05f0)
 optimization_args = [:maxiters => 300]
 
 # Run benchmark
-endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5e-3)
+endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 6e-3)
 benchmarking_results = benchmark(
     open_loop_pendulum_dynamics,
     lb,
@@ -92,7 +92,6 @@ benchmarking_results = benchmark(
     optimization_args,
     state_syms,
     parameter_syms,
-    policy_search = true,
     endpoint_check,
     init_params = ps, 
     init_states = st
@@ -182,7 +181,7 @@ nothing # hide
 Since the pendulum is periodic in ``0``, we'll use a custom endpoint check that reflects that property.
 
 ```@example benchmarking
-endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol=5e-3)
+endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 6e-3)
 nothing # hide
 ```
 
@@ -214,7 +213,6 @@ benchmarking_results = benchmark(
     optimization_args,
     state_syms,
     parameter_syms,
-    policy_search = true,
     ensemble_alg = EnsembleSerial(),
     endpoint_check,
     init_params = ps, 

--- a/docs/src/man/internals.md
+++ b/docs/src/man/internals.md
@@ -3,4 +3,11 @@
 ```@docs
 NeuralLyapunov.phi_to_net
 NeuralLyapunov.NeuralLyapunovBenchmarkLogger
+NeuralLyapunov.AbstractNeuralLyapunovStructure
+NeuralLyapunov.get_V
+NeuralLyapunov.get_V̇
+NeuralLyapunov.neural_controller
+NeuralLyapunov.get_network_dim
+NeuralLyapunov.get_control_dim
+NeuralLyapunov.get_control_structure
 ```

--- a/docs/src/man/policy_search.md
+++ b/docs/src/man/policy_search.md
@@ -3,11 +3,12 @@
 At times, we wish to model a component of the dynamics with a neural network.
 A common example is the policy search case, when the closed-loop dynamics include a neural network controller.
 In such cases, we consider the dynamics to take the form of ``\frac{dx}{dt} = f(x, u, p, t)``, where ``u`` is the control input/the contribution to the dynamics from the neural network.
-We provide the [`add_policy_search`](@ref) function to transform a [`NeuralLyapunovStructure`](@ref) to include training the neural network to represent not just the Lyapunov function, but also the relevant part of the dynamics.
+We provide the [`add_policy_search`](@ref) function to transform a [`NeuralLyapunovStructure`](@ref) into a [`NeuralLyapunovControlStructure`](@ref) to include training the neural network to represent not just the Lyapunov function, but also the relevant part of the dynamics.
 
 Similar to [`get_numerical_lyapunov_function`](@ref), we provide the [`get_policy`](@ref) convenience function to construct ``u(x)`` that can be combined with the open-loop dynamics ``f(x, u, p, t)`` to create closed loop dynamics ``f_{cl}(x, p, t) = f(x, u(x), p, t)``.
 
 ```@docs
 add_policy_search
 get_policy
+NeuralLyapunovControlStructure
 ```

--- a/docs/src/man/structure.md
+++ b/docs/src/man/structure.md
@@ -4,7 +4,7 @@ Users have two ways to specify the structure of their neural Lyapunov function: 
 NeuralLyapunov.jl is intended for use with [NeuralPDE.jl](https://github.com/SciML/NeuralPDE.jl), which is itself intended for use with [Lux.jl](https://github.com/LuxDL/Lux.jl).
 Users therefore must provide a Lux model representing the neural network ``\phi(x)`` which will be trained, regardless of the transformation they use to go from ``\phi`` to ``V``.
 
-In some cases, users will find it simplest to make ``\phi(x)`` a simple multilayer perceptron and specify their neural Lyapunov function structure as a transformation of the function ``\phi`` to the function ``V`` using the [`NeuralLyapunovStructure`](@ref) struct, detailed below.
+In some cases, users will find it simplest to make ``\phi(x)`` a simple multilayer perceptron and specify their neural Lyapunov function structure as a transformation of the function ``\phi`` to the function ``V`` using the [`NeuralLyapunovStructure`](@ref) or [`NeuralLyapunovControlStructure`](@ref) struct, detailed below.
 
 In other cases (particularly when they find the NeuralPDE parser has trouble tracing their structure), users may wish to represent their neuralLyapunov function structure using [Lux.jl](https://github.com/LuxDL/Lux.jl)/[Boltz.jl](https://github.com/LuxDL/Boltz.jl) layers, integrating them into ``\phi(x)`` and letting ``V(x) = \phi(x)`` (as in [`NoAdditionalStructure`](@ref), detailed below).
 
@@ -60,38 +60,22 @@ StrictlyPositiveSoSPooling
 
 ## Defining your own neural Lyapunov function structure with [`NeuralLyapunovStructure`](@ref)
 
-To define a new structure for a neural Lyapunov function, one must specify the form of the Lyapunov candidate ``V`` and its time derivative along a trajectory ``\dot{V}``, as well as how to call the dynamics ``f``.
+To define a new structure for a neural Lyapunov function, one must specify the form of the Lyapunov candidate ``V`` and its time derivative along a trajectory ``\dot{V}``.
 Additionally, the dimensionality of the output of the neural network must be known in advance.
 
 ```@docs
 NeuralLyapunovStructure
 ```
 
-### Calling the dynamics
-
-Very generally, the dynamical system can be a system of ODEs ``\dot{x} = f(x, u, p, t)``, where ``u`` is a control input, ``p`` contains parameters, and ``f`` depends on the neural network in some way.
-To capture this variety, users must supply the function `f_call(dynamics, phi, state, p, t)`.
-
-The most common example is when `dynamics` takes the same form as an `ODEFunction`. 
-i.e., ``\dot{x} = \texttt{dynamics}(x, p, t)``.
-In that case, `f_call(dynamics, phi, state, p, t) = dynamics(state, p, t)`.
-
-Suppose instead, the dynamics were supplied as a function of state alone: ``\dot{x} = \texttt{dynamics}(x)``.
-Then, `f_call(dynamics, phi, state, p, t) = dynamics(state)`.
-
-Finally, suppose ``\dot{x} = \texttt{dynamics}(x, u, p, t)`` has a unidimensional control input that is being trained (via [policy search](policy_search.md)) to be the second output of the neural network.
-Then `f_call(dynamics, phi, state, p, t) = dynamics(state, phi(state)[2], p, t)`.
-
-Note that, despite the inclusion of the time variable ``t``, NeuralLyapunov.jl currently only supports time-invariant systems, so only `t = 0.0` is used.
+[`NeuralLyapunovStructure`](@ref) is appropriate for dynamics ``\frac{dx}{dt} = f(x, p, t)`` which do not depend on the neural network. If the dynamics depend on a neural network being trained jointly with the neural Lyapunov function, use [`NeuralLyapunovControlStructure`](@ref) as detailed on the [*Policy Search and Network-Dependent Dynamics*](policy_search.md) page.
 
 ### Structuring ``V`` and ``\dot{V}``
 
-The Lyapunov candidate function ``V`` gets specified as a function `V(phi, state, fixed_point)`, where `phi` is the neural network as a function `phi(state)`.
+The Lyapunov candidate function ``V`` gets specified as a function `V(phi, x, x0)`, where `phi` is the neural network as a function `phi(x)`.
 Note that this form allows ``V(x)`` to depend on the neural network evaluated at points other than just the input ``x``.
 
-The time derivative ``\dot{V}`` is similarly defined by a function `V̇(phi, J_phi, dynamics, state, params, t, fixed_point)`.
-The function `J_phi(state)` gives the Jacobian of the neural network `phi` at `state`.
-The function `dynamics` is as above (with parameters `params`). 
+The time derivative ``\dot{V}`` is similarly defined by a function `V̇(phi, J_phi, x, ẋ, x0)`.
+The function `J_phi(x)` gives the Jacobian of the neural network `phi` at `x`.
 
 ## References
 ```@bibliography

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -41,8 +41,8 @@ include("benchmark_harness.jl")
 include("lux_structures.jl")
 
 # Lyapunov function structures
-export NeuralLyapunovStructure, NoAdditionalStructure, NonnegativeStructure,
-    PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
+export NeuralLyapunovStructure, NeuralLyapunovControlStructure, NoAdditionalStructure,
+    NonnegativeStructure, PositiveSemiDefiniteStructure, get_numerical_lyapunov_function
 
 # Lux structures
 export AdditiveLyapunovNet, MultiplicativeLyapunovNet, SoSPooling,

--- a/src/NeuralLyapunovPDESystem.jl
+++ b/src/NeuralLyapunovPDESystem.jl
@@ -7,7 +7,7 @@ Construct a `ModelingToolkit.PDESystem` representing the specified neural Lyapun
 # Positional Arguments
   - `dynamics`: the dynamical system being analyzed, represented as a `System` or the
     function `f` such that `ẋ = f(x[, u], p, t)`; either way, the ODE should not depend on
-    time and only `t = 0.0` will be used. (For an example of when `f` would have a `u`
+    time and only `t = 0` will be used. (For an example of when `f` would have a `u`
     argument, see [`add_policy_search`](@ref).) If `dynamics isa System`, call
     `mtkcompile(dynamics)` before `NeuralLyapunovPDESystem`, or
     `mtkcompile(dynamics; inputs = ..., split = false)` if the system has unbound inputs.
@@ -49,7 +49,6 @@ function NeuralLyapunovPDESystem(
         p = SciMLBase.NullParameters(),
         state_syms = [],
         parameter_syms = [],
-        policy_search::Bool = false,
         name
     )::PDESystem
     ########################## Define state symbols ###########################
@@ -64,9 +63,19 @@ function NeuralLyapunovPDESystem(
     ######################## Define parameter symbols #########################
     # Define parameter symbols, if not already defined
     if p == SciMLBase.NullParameters()
-        parameter_syms = []
+        if !isempty(parameter_syms)
+            error(
+                "Got nonempty parameter_syms when p == SciMLBase.NullParameters(). " *
+                    "Please provide p or leave parameter_syms empty."
+            )
+        end
     elseif isempty(parameter_syms)
         parameter_syms = [Symbol(:p, i) for i in 1:length(p)]
+    elseif length(parameter_syms) != length(p)
+        error(
+            "Length of parameter_syms ($(length(parameter_syms))) and of p ($(length(p)))" *
+                " do not match."
+        )
     end
 
     params = [first(@parameters $s) for s in parameter_syms]
@@ -80,6 +89,9 @@ function NeuralLyapunovPDESystem(
 
     ############################# Define domains ##############################
     domains = [state[i] in (lb[i], ub[i]) for i in 1:state_dim]
+
+    ######################### Check for policy search #########################
+    policy_search = neural_controller(spec.structure)
 
     ########################### Construct PDESystem ###########################
     return _NeuralLyapunovPDESystem(
@@ -104,7 +116,6 @@ function NeuralLyapunovPDESystem(
         p = SciMLBase.NullParameters(),
         state_syms = [],
         parameter_syms = [],
-        policy_search::Bool = dynamics isa ODEInputFunction,
         name
     )::PDESystem
     if dynamics.mass_matrix !== I
@@ -115,18 +126,20 @@ function NeuralLyapunovPDESystem(
             )
         )
     end
+
+    policy_search = neural_controller(spec.structure)
     if policy_search && (dynamics isa ODEFunction)
         throw(
             ErrorException(
-                "Got policy_search == true when dynamics were supplied as an" *
-                    " ODEFunction f(x,p,t), so no input can be supplied."
+                "Got spec.structure isa AbstractNeuralLyapunovStructure{true} when " *
+                    "dynamics were supplied as an ODEFunction f(x,p,t)."
             )
         )
     elseif !policy_search && (dynamics isa ODEInputFunction)
         throw(
             ErrorException(
-                "Got policy_search == false when dynamics were supplied as " *
-                    "an ODEInputFunction f(x,u,p,t)."
+                "Got spec.structure isa AbstractNeuralLyapunovStructure{false} when " *
+                    "dynamics were supplied as an ODEInputFunction f(x,u,p,t)."
             )
         )
     end
@@ -165,7 +178,6 @@ function NeuralLyapunovPDESystem(
         p,
         state_syms = s_syms,
         parameter_syms = p_syms,
-        policy_search = false,
         name
     )
 end
@@ -179,6 +191,21 @@ function NeuralLyapunovPDESystem(
     )::PDESystem
     ######################### Check for policy search #########################
     policy_search = !isempty(unbound_inputs(dynamics))
+    if policy_search && !neural_controller(spec.structure)
+        throw(
+            ErrorException(
+                "Got unbound inputs in dynamics but spec.structure isa " *
+                    "AbstractNeuralLyapunovStructure{false}."
+            )
+        )
+    elseif !policy_search && neural_controller(spec.structure)
+        throw(
+            ErrorException(
+                "Got spec.structure isa AbstractNeuralLyapunovStructure{true} but no " *
+                    "unbound inputs in dynamics."
+            )
+        )
+    end
 
     f = if policy_search
         ODEInputFunction(dynamics)
@@ -232,39 +259,44 @@ function _NeuralLyapunovPDESystem(
     structure = spec.structure
     minimization_condition = spec.minimization_condition
     decrease_condition = spec.decrease_condition
-    f_call = structure.f_call
-    state_dim = length(domains)
 
     ################## Define Lyapunov function & derivative ##################
-    output_dim = structure.network_dim
+    output_dim = get_network_dim(structure)
+    control_dim = policy_search ? get_control_dim(structure) : 0
     net_syms = [Symbol(:φ, i) for i in 1:output_dim]
     net = [first(@variables $s(..)) for s in net_syms]
 
     # φ(x) is the symbolic form of neural network output
-    φ(x) = Num.([φi(x...) for φi in net])
+    φ(x) = Num.([φi(x...) for φi in net[1:(output_dim - control_dim)]])
+
+    # u(x) is the symbolic form of the control input, when applicable
+    if policy_search
+        φu(x) = Num.([φi(x...) for φi in net[(output_dim - control_dim + 1):end]])
+        _u = get_control_structure(structure)
+        u(x) = _u(φu, x, fixed_point)
+    end
 
     # V(x) is the symbolic form of the Lyapunov function
-    V(x) = structure.V(φ, x, fixed_point)
+    _V = get_V(structure)
+    V(x) = _V(φ, x, fixed_point)
 
     # V̇(x) is the symbolic time derivative of the Lyapunov function
-    function V̇(x)
-        return structure.V̇(
-            φ,
-            y -> Symbolics.jacobian(φ(y), y),
-            dynamics,
-            x,
-            params,
-            0.0,
-            fixed_point
-        )
+    if policy_search
+        f = x -> dynamics(x, u(x), params, 0)
+    else
+        f = x -> dynamics(x, params, 0)
     end
+    _V̇ = get_V̇(structure)
+    Jφ(x) = Symbolics.jacobian(φ(x), x)
+    V̇(x) = _V̇(φ, Jφ, x, f(x), fixed_point)
+
 
     ################ Define equations and boundary conditions #################
     eqs = Equation[]
 
     if check_nonnegativity(minimization_condition)
         cond = get_minimization_condition(minimization_condition)::Function
-        cond_eq = cond(V, state, fixed_point) .~ 0.0
+        cond_eq = cond(V, state, fixed_point) .~ 0
         if cond_eq isa Equation
             push!(eqs, cond_eq)
         elseif cond_eq isa AbstractVector{Equation}
@@ -279,7 +311,7 @@ function _NeuralLyapunovPDESystem(
 
     if check_decrease(decrease_condition)
         cond = get_decrease_condition(decrease_condition)::Function
-        cond_eq = cond(V, V̇, state, fixed_point) .~ 0.0
+        cond_eq = cond(V, V̇, state, fixed_point) .~ 0
         if cond_eq isa Equation
             push!(eqs, cond_eq)
         elseif cond_eq isa AbstractVector{Equation}
@@ -295,24 +327,24 @@ function _NeuralLyapunovPDESystem(
     bcs = Equation[]
 
     if check_minimal_fixed_point(minimization_condition)
-        _V = V(fixed_point)
-        _V = _V isa AbstractVector ? _V[] : _V
-        push!(bcs, _V ~ 0.0)
+        V0 = V(fixed_point)
+        V0 = V0 isa AbstractVector ? V0[] : V0
+        push!(bcs, V0 ~ 0)
     end
 
     if policy_search
-        append!(bcs, f_call(dynamics, φ, fixed_point, params, 0.0) .~ zeros(state_dim))
+        append!(bcs, f(fixed_point) .~ 0)
     end
 
     if isempty(eqs) && isempty(bcs)
         error("No training conditions specified.")
     end
 
-    # NeuralPDE requires an equation and a boundary condition, even if they are
-    # trivial like φ(0.0) == φ(0.0), so we remove those trivial equations if they showed up
-    # naturally alongside other equations and add them in if we have no other equations
-    eqs = filter(eq -> eq != (0.0 ~ 0.0), eqs)
-    bcs = filter(eq -> eq != (0.0 ~ 0.0), bcs)
+    # NeuralPDE requires an equation and a boundary condition, even if they are trivial
+    # like φ(0) ~ φ(0), so we remove any trivial equations if they showed up naturally
+    # alongside other equations and add some in if we have no other equations
+    eqs = filter(eq -> eq != (0 ~ 0), eqs)
+    bcs = filter(eq -> eq != (0 ~ 0), bcs)
 
     if isempty(eqs)
         push!(eqs, φ(fixed_point)[1] ~ φ(fixed_point)[1])
@@ -322,12 +354,13 @@ function _NeuralLyapunovPDESystem(
     end
 
     ########################### Construct PDESystem ###########################
+    dvs = policy_search ? vcat(φ(state), φu(state)) : φ(state)
     return PDESystem(
         eqs,
         bcs,
         domains,
         state,
-        φ(state),
+        dvs,
         params;
         initial_conditions,
         name

--- a/src/benchmark_harness.jl
+++ b/src/benchmark_harness.jl
@@ -83,10 +83,6 @@ the user or generated automatically).
     `dynamics` is an `ODEFunction` or an `ODEInputFunction`, the symbols stored there are
     used, unless overridden here; if not provided here and cannot be inferred,
     `[:param1, :param2, ...]` will be used.
-  - `policy_search::Bool`: whether or not to include a loss term enforcing `fixed_point` to
-    actually be a fixed point; defaults to `false`; when `dynamics isa System`, the value
-    is inferred by the presence of unbound inputs and when `dynamics` is an `ODEFunction` or
-    an `ODEInputFunction`, the value is inferred by the type of `dynamics`.
   - `optimization_args`: arguments to be passed into the optimization solver, as a vector of
     `Pair`s. For more information, see the
     [Optimization.jl docs](https://docs.sciml.ai/Optimization/stable/API/solve/).
@@ -283,7 +279,6 @@ function benchmark(
         p = SciMLBase.NullParameters(),
         state_syms = [],
         parameter_syms = [],
-        policy_search = false,
         optimization_args = [],
         simulation_time,
         ode_solver = AutoTsit5(Rosenbrock23()),
@@ -354,7 +349,6 @@ function benchmark(
         p,
         state_syms,
         parameter_syms,
-        policy_search
     )
 
     _classifier(V, V̇, x) = classifier(V, V̇, x) || endpoint_check(x)
@@ -443,11 +437,9 @@ function _benchmark(
         p
     )
 
-    f = if f isa ODEFunction
-        f
-    else
-        let fc = spec.structure.f_call, _f = f, net = phi_to_net(phi, θ)
-            ODEFunction((x, _p, t) -> fc(_f, net, x, _p, t))
+    if neural_controller(spec.structure)
+        f = let _f = f, u = get_policy(phi, θ, spec.structure; fixed_point)
+            ODEFunction((x, _p, t) -> _f(x, u(x), _p, t))
         end
     end
 

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -123,8 +123,8 @@ end
 
 Return the control structure specified by `spec`.
 """
-function get_control_structure(str::AbstractNeuralLyapunovStructure{nc}) where nc
-    if nc
+function get_control_structure(str::AbstractNeuralLyapunovStructure{nc}) where {nc}
+    return if nc
         error(
             "control_structure not implemented for AbstractNeuralLyapunovStructure of " *
                 "type $(typeof(str))."
@@ -139,8 +139,8 @@ end
 
 Return the control dimension specified by `spec`.
 """
-function get_control_dim(str::AbstractNeuralLyapunovStructure{nc}) where nc
-    if nc
+function get_control_dim(str::AbstractNeuralLyapunovStructure{nc}) where {nc}
+    return if nc
         error(
             "control_dim not implemented for AbstractNeuralLyapunovStructure of type " *
                 string(typeof(str))
@@ -156,7 +156,7 @@ end
 Return `true` if `str` specifies a neural controller (i.e., if `str` is a subtype of
 `AbstractNeuralLyapunovStructure{true}`) and `false` otherwise.
 """
-neural_controller(::AbstractNeuralLyapunovStructure{nc}) where nc = nc
+neural_controller(::AbstractNeuralLyapunovStructure{nc}) where {nc} = nc
 
 """
     check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -1,117 +1,13 @@
 """
-    NeuralLyapunovStructure(V, V̇, f_call, network_dim)
+    AbstractNeuralLyapunovStructure{nc}
 
-Specifies the structure of the neural Lyapunov function and its derivative.
+Represents the structure of the neural Lyapunov function and its derivative.
 
-Allows the user to define the Lyapunov in terms of the neural network, potentially
-structurally enforcing some Lyapunov conditions.
-
-# Fields
-  - `V(phi, state, fixed_point)`: outputs the value of the Lyapunov function at `state`.
-  - `V̇(phi, J_phi, dynamics, state, params, t, fixed_point)`: outputs the time derivative of
-    the Lyapunov function at `state`.
-  - `f_call(dynamics, phi, state, params, t)`: outputs the derivative of the state; this is
-    useful for making closed-loop dynamics which depend on the neural network, such as in
-    the policy search case.
-  - `network_dim`: the dimension of the output of the neural network.
-
-`phi` and `J_phi` above are both functions of `state` alone.
+All concrete `AbstractNeuralLyapunovStructure` subtypes should define the `get_V`, `get_V̇`,
+and `get_network_dim` functions. If `nc` is `true`, the subtype should also define the
+`get_control_structure` and `get_control_dim` functions.
 """
-struct NeuralLyapunovStructure{TV, TDV, F, D <: Integer}
-    V::TV
-    V̇::TDV
-    f_call::F
-    network_dim::D
-end
-
-function Base.show(io::IO, s::NeuralLyapunovStructure)
-    n = s.network_dim
-    if n > 1
-        @variables φ(..)[1:n] Jφ(..)[1:n, 1:1] f(..) x x_0 p t
-        println(io, "NeuralLyapunovStructure")
-        println(io, "    Network dimension: ", n)
-        try
-            V = string(s.V(φ, x, x_0))
-            # Regex to simplify broadcasting notation for better readability
-            # Replace, e.g., [1:1] with [1]
-            V = replace(V, r"\b(\d+):\1\b" => s"\1")
-            # Replace LinearAlgebra.dot(A, A) with ||A||^2 for better readability
-            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?1)\))*)\s*\)"
-            V = replace(V, dot_re => s"||\1||²")
-            # Replace abs2(A) with ||A||^2 for better readability
-            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
-            # Replace LinearAlgebra.dot with ⋅ for better readability
-            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
-            V = replace(V, dot_re => s"(\1)⋅(\2)")
-            # Replace ^2 with ²
-            V = replace(V, r"\^2" => "²")
-            println(io, "    V(x) = ", V)
-        catch e
-            println(io, "    V(x) = <could not display: $e>")
-        end
-        try
-            V̇ = string(s.V̇(φ, Jφ, f, x, p, t, x_0))
-            # Regex to simplify broadcasting notation for better readability
-            # Replace, e.g., [1:2, Colon()] with [1:2]
-            V̇ = replace(V̇, r",\s*Colon\(\)" => "")
-            # Replace, e.g., [1:1] with [1]
-            V̇ = replace(V̇, r"\b(\d+):\1\b" => s"\1")
-            # Replace abs2(A) with ||A||^2 for better readability
-            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
-            # Replace LinearAlgebra.dot with ⋅ for better readability
-            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
-            V̇ = replace(V̇, dot_re => s"(\1)⋅(\2)")
-            # Replace ^2 with ²
-            V̇ = replace(V̇, r"\^2" => "²")
-            # Replace Differential(x, 1)(φ(x)) with Jφ(x) for better readability
-            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "Jφ(x)")
-            println(io, "    V̇(x) = ", V̇)
-        catch e
-            println(io, "    V̇(x) = <could not display: $(e)>")
-        end
-        try
-            ẋ = string(s.f_call(f, φ, x, p, t))
-            # Regex to simplify broadcasting notation for better readability
-            # Replace, e.g., [1:1] with [1]
-            ẋ = replace(ẋ, r"\b(\d+):\1\b" => s"\1")
-            print(io, "    f_call(x) = ", ẋ)
-        catch e
-            println(io, "    f_call(x) = <could not display: $(e)>")
-        end
-    else
-        @variables φ(..) ∇φ(..) f(..) x x_0 p t
-        println(io, "NeuralLyapunovStructure")
-        println(io, "    Network dimension: ", n)
-        try
-            V = string(s.V(φ, x, x_0))
-            # Replace abs2(A) with ||A||² for better readability
-            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
-            # Replace ^2 with ²
-            V = replace(V, r"\^2" => "²")
-            println(io, "    V(x) = ", V)
-        catch e
-            println(io, "    V(x) = <could not display: $(e)>")
-        end
-        try
-            V̇ = string(s.V̇(φ, ∇φ, f, x, p, t, x_0))
-            # Replace abs2(A) with ||A||^2 for better readability
-            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
-            # Replace ^2 with ²
-            V̇ = replace(V̇, r"\^2" => "²")
-            # Replace Differential(x, 1)(φ(x)) with ∇φ(x) for better readability
-            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "∇φ(x)")
-            println(io, "    V̇(x) = ", V̇)
-        catch e
-            println(io, "    V̇(x) = <could not display: $(e)>")
-        end
-        try
-            print(io, "    f_call(x) = ", s.f_call(f, φ, x, p, t))
-        catch e
-            println(io, "    f_call(x) = <could not display: $(e)>")
-        end
-    end
-    return
-end
+abstract type AbstractNeuralLyapunovStructure{nc} end
 
 """
     AbstractLyapunovMinimizationCondition
@@ -147,15 +43,14 @@ Specifies a neural Lyapunov problem.
     decrease condition will be enforced.
 
 # Example
-```jldoctest; filter = [r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"φ\\(x\\)" => "φ", r"\\s*\\*\\s*" => "", r"∇φ" => "∇", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(2|φ|∇|ẋ){4}\$"]
+```julia
 julia> NeuralLyapunovSpecification(NonnegativeStructure(1), PositiveSemiDefinite(), StabilityISL())
 NeuralLyapunovSpecification
     Structure:
         NeuralLyapunovStructure
             Network dimension: 1
             V(x) = φ(x)²
-            V̇(x) = 2φ(x)*∇φ(x)*f(x, p, t)
-            f_call(x) = f(x, p, t)
+            V̇(x) = 2ẋ*∇φ(x)*φ(x)
     Minimization Condition:
         LyapunovMinimizationCondition
             Trains for V(x) ≥ 0.0
@@ -168,7 +63,7 @@ NeuralLyapunovSpecification
 ```
 """
 struct NeuralLyapunovSpecification
-    structure::NeuralLyapunovStructure
+    structure::AbstractNeuralLyapunovStructure
     minimization_condition::AbstractLyapunovMinimizationCondition
     decrease_condition::AbstractLyapunovDecreaseCondition
 end
@@ -181,9 +76,87 @@ function Base.show(io::IO, spec::NeuralLyapunovSpecification)
     println(io, "    Minimization Condition:")
     println(io, replace(string(spec.minimization_condition), r"^(?=.)"m => "        "))
     println(io, "    Decrease Condition:")
-    print(io, replace(string(spec.decrease_condition), r"^(?=.)"m => "        "))
+    print(io, replace(string(spec.decrease_condition), r"^(?=.)"m => "        ", r"(ẋ|ẋ)" => "ẋ"))
     return
 end
+
+"""
+    get_V(str::AbstractNeuralLyapunovStructure)
+
+Return a function `V(phi, state, fixed_point)` that outputs the value of the Lyapunov
+function at `state`.
+"""
+function get_V(str::AbstractNeuralLyapunovStructure)
+    error(
+        "get_V not implemented for AbstractNeuralLyapunovStructure of type " *
+            string(typeof(str)) * "."
+    )
+end
+
+"""
+    get_V̇(str::AbstractNeuralLyapunovStructure)
+
+Return a function `V̇(phi, J_phi, state, dstate_dt, fixed_point)` that outputs the
+time derivative of the Lyapunov function at `state`.
+"""
+function get_V̇(str::AbstractNeuralLyapunovStructure)
+    error(
+        "get_V̇ not implemented for AbstractNeuralLyapunovStructure of type " *
+            string(typeof(str)) * "."
+    )
+end
+
+"""
+    get_network_dim(str::AbstractNeuralLyapunovStructure)
+
+Return the number of dimensions of the neural network output specified by `spec`.
+"""
+function get_network_dim(str::AbstractNeuralLyapunovStructure)
+    error(
+        "get_network_dim not implemented for AbstractNeuralLyapunovStructure of type " *
+            string(typeof(str)) * "."
+    )
+end
+
+"""
+    get_control_structure(str::AbstractNeuralLyapunovStructure{true})
+
+Return the control structure specified by `spec`.
+"""
+function get_control_structure(str::AbstractNeuralLyapunovStructure{nc}) where nc
+    if nc
+        error(
+            "control_structure not implemented for AbstractNeuralLyapunovStructure of " *
+                "type $(typeof(str))."
+        )
+    else
+        error("control_structure not defined for AbstractNeuralLyapunovStructure{false}.")
+    end
+end
+
+"""
+    get_control_dim(str::AbstractNeuralLyapunovStructure{true})
+
+Return the control dimension specified by `spec`.
+"""
+function get_control_dim(str::AbstractNeuralLyapunovStructure{nc}) where nc
+    if nc
+        error(
+            "control_dim not implemented for AbstractNeuralLyapunovStructure of type " *
+                string(typeof(str))
+        )
+    else
+        error("control_dim not defined for AbstractNeuralLyapunovStructure{false}.")
+    end
+end
+
+"""
+    neural_controller(str::AbstractNeuralLyapunovStructure)
+
+Return `true` if `str` specifies a neural controller (i.e., if `str` is a subtype of
+`AbstractNeuralLyapunovStructure{true}`) and `false` otherwise.
+"""
+neural_controller(::AbstractNeuralLyapunovStructure{nc}) where nc = nc
 
 """
     check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)
@@ -194,7 +167,7 @@ Return `true` if `cond` specifies training to meet the Lyapunov minimization con
 function check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)::Bool
     error(
         "check_nonnegativity not implemented for AbstractLyapunovMinimizationCondition " *
-            "of type $(typeof(cond))"
+            "of type $(typeof(cond))."
     )
 end
 
@@ -207,7 +180,7 @@ fixed point, and `false` if `cond` specifies no training to meet this condition.
 function check_minimal_fixed_point(cond::AbstractLyapunovMinimizationCondition)::Bool
     error(
         "check_minimal_fixed_point not implemented for " *
-            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))"
+            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))."
     )
 end
 
@@ -228,7 +201,7 @@ condition to be considered met.
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
     error(
         "get_minimization_condition not implemented for " *
-            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))"
+            "AbstractLyapunovMinimizationCondition of type $(typeof(cond))."
     )
 end
 
@@ -259,7 +232,7 @@ Return `true` if `cond` specifies training to meet the Lyapunov decrease conditi
 function check_decrease(cond::AbstractLyapunovDecreaseCondition)::Bool
     error(
         "check_decrease not implemented for AbstractLyapunovDecreaseCondition of type " *
-            string(typeof(cond))
+            string(typeof(cond)) * "."
     )
 end
 
@@ -279,7 +252,7 @@ condition to be considered met.
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
     error(
         "get_decrease_condition not implemented for AbstractLyapunovDecreaseCondition " *
-            "of type $(typeof(cond))"
+            "of type $(typeof(cond))."
     )
 end
 

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -20,8 +20,7 @@ ensure that `dynamics` can operate on GPU arrays (e.g., be careful about scalar 
     single output, `θ` should be the parameters of the network.
   - `structure`: a [`NeuralLyapunovStructure`](@ref) representing the structure of the
     neural Lyapunov function.
-  - `dynamics`: the system dynamics, as a function to be used in conjunction with
-    `structure.f_call`.
+  - `dynamics`: the system dynamics, as a function `ẋ = f(x[, u], p, t)`.
   - `fixed_point`: the equilibrium point being analyzed by the Lyapunov function.
 
 # Keyword Arguments
@@ -40,7 +39,7 @@ ensure that `dynamics` can operate on GPU arrays (e.g., be careful about scalar 
 function get_numerical_lyapunov_function(
         phi,
         θ,
-        structure::NeuralLyapunovStructure,
+        structure::AbstractNeuralLyapunovStructure{nc},
         dynamics,
         fixed_point::AbstractVector;
         p = SciMLBase.NullParameters(),
@@ -48,17 +47,22 @@ function get_numerical_lyapunov_function(
         deriv = ForwardDiff.derivative,
         jac = ForwardDiff.jacobian,
         J_net = nothing
-    )
+    ) where nc
     # network_func is the numerical form of neural network output
-    network_func = phi_to_net(phi, θ)
-
-    # V is the numerical form of Lyapunov function
-    V = let V_structure = structure.V, net = network_func, x0 = fixed_point
-        V(state::AbstractVector) = V_structure(net, state, x0)
-        V(states::AbstractMatrix) = mapslices(V, states, dims = [1])
+    if nc
+        u_dim = get_control_dim(structure)
+        φ_dim = get_network_dim(structure) - u_dim
+        network_func = phi_to_net(phi, θ; idx = 1:φ_dim)
+    else
+        φ_dim = get_network_dim(structure)
+        network_func = phi_to_net(phi, θ)
     end
 
-    return if use_V̇_structure
+
+    # V is the numerical form of Lyapunov function
+    V = get_numerical_V(structure.V, network_func, copy(fixed_point))
+
+    if use_V̇_structure
         # Make Jacobian of network_func
         network_jacobian = if isnothing(J_net)
             let net = network_func, J = jac
@@ -70,36 +74,99 @@ function get_numerical_lyapunov_function(
             end
         end
 
-        let _V = V, V̇_structure = structure.V̇, net = network_func, x0 = fixed_point,
-                f = dynamics, params = p, _J_net = network_jacobian
-
-            # Numerical time derivative of Lyapunov function
-            V̇(state::AbstractVector) = V̇_structure(net, _J_net, f, state, params, 0.0, x0)
-            V̇(states::AbstractMatrix) = mapslices(V̇, states, dims = [1])
-
-            return _V, V̇
+        V̇ = if nc
+            get_V̇_from_structure(
+                structure.V̇,
+                network_func,
+                network_jacobian,
+                dynamics,
+                copy(p),
+                copy(fixed_point),
+                get_control_structure(structure)
+            )
+        else
+            get_V̇_from_structure(
+                structure.V̇,
+                network_func,
+                network_jacobian,
+                dynamics,
+                copy(p),
+                copy(fixed_point)
+            )
         end
+        return V, V̇
     else
-        let f_call = structure.f_call, _V = V, net = network_func, f = dynamics, params = p,
-                _deriv = deriv
-
-            # Numerical time derivative of Lyapunov function
-            function V̇(state::AbstractVector)
-                return _deriv(
-                    δt -> _V(state + δt * f_call(f, net, state, params, 0.0)),
-                    0.0
-                )
-            end
-            function V̇(states::AbstractMatrix)
-                ẋ = mapslices(states, dims = [1]) do state
-                    return f_call(f, net, state, params, 0.0)
-                end
-                return _deriv(δt -> _V(states + δt * ẋ), 0.0)
-            end
-
-            return _V, V̇
+        V̇ = if nc
+            control_network = phi_to_net(phi, θ; idx = (φ_dim + 1):(φ_dim + u_dim))
+            get_V̇_from_deriv(
+                V,
+                dynamics,
+                copy(p),
+                deriv,
+                get_control_structure(structure),
+                control_network,
+                copy(fixed_point)
+            )
+        else
+            get_V̇_from_deriv(V, dynamics, copy(p), deriv)
         end
+        return V, V̇
     end
+end
+
+function get_numerical_V(V_structure, net, x0)
+    V(x::AbstractVector) = V_structure(net, x, x0)
+    V(x::AbstractMatrix) = mapslices(V, x, dims = [1])
+    return V
+end
+
+function get_V̇_from_structure(V̇_structure, net, J_net, f, params, x0)
+    # Numerical time derivative of Lyapunov function
+    function V̇(x::AbstractVector{T}) where T <: Real
+        dstate_dt = f(x, params, zero(T))
+        return V̇_structure(net, J_net, x, dstate_dt, x0)
+    end
+    function V̇(x::AbstractMatrix)
+        return mapslices(V̇, x, dims = [1])
+    end
+    return V̇
+end
+
+function get_V̇_from_structure(V̇_structure, net, J_net, f, params, x0, u)
+    # Numerical time derivative of Lyapunov function
+    function V̇(x::AbstractVector{T}) where T <: Real
+        dstate_dt = f(x, u(net, x, x0), params, zero(T))
+        return V̇_structure(net, J_net, x, dstate_dt, x0)
+    end
+    function V̇(x::AbstractMatrix)
+        return mapslices(V̇, x, dims = [1])
+    end
+    return V̇
+end
+
+function get_V̇_from_deriv(V, f, p, deriv)
+    function V̇(x::AbstractVector{T}) where T <: Real
+        return deriv(δt -> V(x + δt * f(x, p, zero(T))), zero(T))
+    end
+    function V̇(x::AbstractMatrix{T}) where T <: Real
+        ẋ = mapslices(x, dims = [1]) do state
+            return f(state, p, zero(T))
+        end
+        return deriv(δt -> V(x + δt * ẋ), zero(T))
+    end
+    return V̇
+end
+
+function get_V̇_from_deriv(V, f, p, deriv, u, u_net, x0)
+    function V̇(x::AbstractVector{T}) where T <: Real
+        ẋ = f(x, u(u_net, x, x0), p, zero(T))
+        return deriv(δt -> V(x + δt * ẋ), zero(T))
+    end
+    function V̇(x::AbstractMatrix{T}) where T <: Real
+        ẋ = mapslices(state -> f(state, u(u_net, state, x0), p, zero(T)), x, dims = [1])
+        return deriv(δt -> V(x + δt * ẋ), zero(T))
+    end
+    return V̇
 end
 
 """

--- a/src/numerical_lyapunov_functions.jl
+++ b/src/numerical_lyapunov_functions.jl
@@ -47,7 +47,7 @@ function get_numerical_lyapunov_function(
         deriv = ForwardDiff.derivative,
         jac = ForwardDiff.jacobian,
         J_net = nothing
-    ) where nc
+    ) where {nc}
     # network_func is the numerical form of neural network output
     if nc
         u_dim = get_control_dim(structure)
@@ -122,7 +122,7 @@ end
 
 function get_V̇_from_structure(V̇_structure, net, J_net, f, params, x0)
     # Numerical time derivative of Lyapunov function
-    function V̇(x::AbstractVector{T}) where T <: Real
+    function V̇(x::AbstractVector{T}) where {T <: Real}
         dstate_dt = f(x, params, zero(T))
         return V̇_structure(net, J_net, x, dstate_dt, x0)
     end
@@ -134,7 +134,7 @@ end
 
 function get_V̇_from_structure(V̇_structure, net, J_net, f, params, x0, u)
     # Numerical time derivative of Lyapunov function
-    function V̇(x::AbstractVector{T}) where T <: Real
+    function V̇(x::AbstractVector{T}) where {T <: Real}
         dstate_dt = f(x, u(net, x, x0), params, zero(T))
         return V̇_structure(net, J_net, x, dstate_dt, x0)
     end
@@ -145,10 +145,10 @@ function get_V̇_from_structure(V̇_structure, net, J_net, f, params, x0, u)
 end
 
 function get_V̇_from_deriv(V, f, p, deriv)
-    function V̇(x::AbstractVector{T}) where T <: Real
+    function V̇(x::AbstractVector{T}) where {T <: Real}
         return deriv(δt -> V(x + δt * f(x, p, zero(T))), zero(T))
     end
-    function V̇(x::AbstractMatrix{T}) where T <: Real
+    function V̇(x::AbstractMatrix{T}) where {T <: Real}
         ẋ = mapslices(x, dims = [1]) do state
             return f(state, p, zero(T))
         end
@@ -158,11 +158,11 @@ function get_V̇_from_deriv(V, f, p, deriv)
 end
 
 function get_V̇_from_deriv(V, f, p, deriv, u, u_net, x0)
-    function V̇(x::AbstractVector{T}) where T <: Real
+    function V̇(x::AbstractVector{T}) where {T <: Real}
         ẋ = f(x, u(u_net, x, x0), p, zero(T))
         return deriv(δt -> V(x + δt * ẋ), zero(T))
     end
-    function V̇(x::AbstractMatrix{T}) where T <: Real
+    function V̇(x::AbstractMatrix{T}) where {T <: Real}
         ẋ = mapslices(state -> f(state, u(u_net, state, x0), p, zero(T)), x, dims = [1])
         return deriv(δt -> V(x + δt * ẋ), zero(T))
     end

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -1,3 +1,77 @@
+
+"""
+    NeuralLyapunovControlStructure(V, V̇, control_structure, network_dim, control_dim)
+
+Specifies the structure of the neural Lyapunov function and its derivative.
+
+Allows the user to define the Lyapunov in terms of the neural network, potentially
+structurally enforcing some Lyapunov conditions.
+
+# Fields
+  - `V(phi, state, fixed_point)`: outputs the value of the Lyapunov function at `state`.
+  - `V̇(phi, J_phi, state, dstate_dt, fixed_point)`: outputs the time derivative of
+    the Lyapunov function at `state`.
+  - `control_structure(phi_c, state, fixed_point)`: transforms the final `control_dim`
+    outputs of the neural net before passing them as `u` into the dynamics `f(x, u, p, t)`.
+  - `network_dim`: the dimension of the output of the neural network.
+  - `control_dim`: the number of neural network outputs used in the control policy.
+
+`phi` and `J_phi` above are both functions of `state` alone.
+"""
+struct NeuralLyapunovControlStructure{TV, TDV, U, D <: Integer, C <: Integer} <: AbstractNeuralLyapunovStructure{true}
+    V::TV
+    V̇::TDV
+    control_structure::U
+    network_dim::D
+    control_dim::C
+end
+
+get_V(spec::NeuralLyapunovControlStructure) = spec.V
+get_V̇(spec::NeuralLyapunovControlStructure) = spec.V̇
+get_network_dim(spec::NeuralLyapunovControlStructure) = spec.network_dim
+get_control_structure(spec::NeuralLyapunovControlStructure) = spec.control_structure
+get_control_dim(spec::NeuralLyapunovControlStructure) = spec.control_dim
+
+function Base.show(io::IO, s::NeuralLyapunovControlStructure)
+    n = s.network_dim
+    @variables φ_V(..) ∇φ_V(..) φ_c(..) ∇φ_c(..) x ẋ x_0 p t
+    println(io, "NeuralLyapunovControlStructure")
+    println(io, "    Network dimension: ", n)
+    try
+        V = string(s.V(φ_V, x, x_0))
+        # Replace abs2(A) with ||A||² for better readability
+        V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+        # Replace ^2 with ²
+        V = replace(V, r"\^2" => "²")
+        println(io, "    V(x) = ", V)
+    catch e
+        println(io, "    V(x) = <could not display: $(e)>")
+    end
+    try
+        V̇ = string(s.V̇(φ_V, ∇φ_V, x, ẋ, x_0))
+        # Replace abs2(A) with ||A||^2 for better readability
+        V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+        # Replace ^2 with ²
+        V̇ = replace(V̇, r"\^2" => "²")
+        # Replace Differential(x, 1)(φ(x)) with ∇φ(x) for better readability
+        V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "∇φ(x)")
+        println(io, "    V̇(x) = ", V̇)
+    catch e
+        println(io, "    V̇(x) = <could not display: $(e)>")
+    end
+    try
+        u = string(s.control_structure(φ_c, x, x_0))
+        # Replace abs2(A) with ||A||^2 for better readability
+        u = replace(u, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+        # Replace ^2 with ²
+        u = replace(u, r"\^2" => "²")
+        println(io, "    u(x) = ", u)
+    catch e
+        println(io, "    u(x) = <could not display: $(e)>")
+    end
+    return
+end
+
 """
     add_policy_search(lyapunov_structure, new_dims; control_structure)
 
@@ -21,51 +95,30 @@ input). When evaluating the dynamics, it uses `u = control_structure(phi_end(x))
 The other `lyapunov_structure.network_dim` outputs are used for calculating ``V`` and ``V̇``,
 as specified originally by `lyapunov_structure`.
 
-```jldoctest
+```jldoctest; filter = [r"(ẋ|ẋ)" => "y", r"\\(x\\)" => "", r"\\s*\\*\\s*" => "", r"∇φ_V" => "∇", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(2|∇|φ_V|y){4}\$"]
 add_policy_search(NonnegativeStructure(3), 1)
 # output
-NeuralLyapunovStructure
+NeuralLyapunovControlStructure
     Network dimension: 4
-    V(x) = ||(φ(x))[1:3]||²
-    V̇(x) = 2((φ(x))[1:3])⋅(f(x, (φ(x))[4], p, t)*(Jφ(x))[1:3])
-    f_call(x) = f(x, (φ(x))[4], p, t)
+    V(x) = φ_V(x)²
+    V̇(x) = 2∇φ_V(x)*φ_V(x)*ẋ
+    u(x) = φ_c(x)
 ```
 """
 function add_policy_search(
-        lyapunov_structure::NeuralLyapunovStructure,
+        lyapunov_structure::AbstractNeuralLyapunovStructure{false},
         new_dims::Integer;
-        control_structure = identity
-    )::NeuralLyapunovStructure
-    return let V = lyapunov_structure.V, V̇ = lyapunov_structure.V̇,
-            V_dim = lyapunov_structure.network_dim, u = control_structure
-
-        NeuralLyapunovStructure(
-            function (net, state, fixed_point)
-                return if length(size(state)) < 2
-                    if V_dim == 1
-                        V(st -> net(st)[1], state, fixed_point)
-                    else
-                        V(st -> net(st)[1:V_dim], state, fixed_point)
-                    end
-                else
-                    V(st -> net(st)[1:V_dim, :], state, fixed_point)
-                end
-            end,
-            function (net, J_net, f, state, params, t, fixed_point)
-                return V̇(
-                    st -> net(st)[1:V_dim], st -> J_net(st)[1:V_dim, :],
-                    (st, p, t) -> f(st, u(net(st)[(V_dim + 1):end]), p, t), state, params,
-                    t, fixed_point
-                )
-            end,
-            (f, net, state, p, t) -> f(state, u(net(state)[(V_dim + 1):end]), p, t),
-            V_dim + new_dims
-        )
+        control_structure = (phi, x, x0) -> phi(x)
+    )::NeuralLyapunovControlStructure
+    let V = get_V(lyapunov_structure), V̇ = get_V̇(lyapunov_structure),
+            V_dim = get_network_dim(lyapunov_structure), u = control_structure
+        return NeuralLyapunovControlStructure(V, V̇, u, V_dim + new_dims, new_dims)
     end
 end
 
 """
-    get_policy(phi, θ, network_dim, control_dim; control_structure)
+    get_policy(phi, θ, network_dim, control_dim; fixed_point, control_structure)
+    get_policy(phi, θ, structure::AbstractNeuralLyapunovStructure{true}; fixed_point)
 
 Generate a Julia function representing the control policy/unmodeled portion of the dynamics
 as a function of the state.
@@ -73,7 +126,7 @@ as a function of the state.
 The returned function can operate on a state vector or columnwise on a matrix of state
 vectors.
 
-# Arguments
+# Positional Arguments
   - `phi`: the neural network, represented as `phi(state, θ)` if the neural network has a
     single output, or a `Vector` of the same with one entry per neural network output.
   - `θ`: the parameters of the neural network; `θ[:φ1]` should be the parameters of the
@@ -81,8 +134,11 @@ vectors.
     second (if there are multiple), and so on.
   - `network_dim`: total number of neural network outputs.
   - `control_dim`: number of neural network outputs used in the control policy.
+  - `structure::AbstractNeuralLyapunovStructure{true}`: provides the control structure and
+    dimensions for the neural network outputs used in the control policy.
 
 # Keyword Arguments
+  - `fixed_point`: the fixed point of the system.
   - `control_structure`: transforms the final `control_dim` outputs of the neural net before
     passing them into the dynamics; defaults to `identity`, passing in the neural network
     outputs unchanged.
@@ -92,20 +148,37 @@ function get_policy(
         θ,
         network_dim::Integer,
         control_dim::Integer;
-        control_structure = identity
+        fixed_point = nothing,
+        control_structure = (phi, x, x0) -> phi(x)
     )
     network_func = phi_to_net(phi, θ; idx = (network_dim - control_dim + 1):network_dim)
 
     function policy(state::AbstractVector)
-        return control_structure(network_func(state))
+        return control_structure(
+            network_func,
+            state,
+            isnothing(fixed_point) ? zero(state) : fixed_point
+        )
     end
     function policy(states::AbstractMatrix)
-        return mapslices(
-            control_structure,
-            network_func(states),
-            dims = [1]
-        )
+        return mapslices(policy, states, dims = [1])
     end
 
     return policy
+end
+
+function get_policy(
+    phi,
+    θ,
+    structure::AbstractNeuralLyapunovStructure{true};
+    fixed_point = nothing
+)
+    return get_policy(
+        phi,
+        θ,
+        get_network_dim(structure),
+        get_control_dim(structure);
+        control_structure = get_control_structure(structure),
+        fixed_point
+    )
 end

--- a/src/policy_search.jl
+++ b/src/policy_search.jl
@@ -1,4 +1,3 @@
-
 """
     NeuralLyapunovControlStructure(V, V̇, control_structure, network_dim, control_dim)
 
@@ -168,11 +167,11 @@ function get_policy(
 end
 
 function get_policy(
-    phi,
-    θ,
-    structure::AbstractNeuralLyapunovStructure{true};
-    fixed_point = nothing
-)
+        phi,
+        θ,
+        structure::AbstractNeuralLyapunovStructure{true};
+        fixed_point = nothing
+    )
     return get_policy(
         phi,
         θ,

--- a/src/structure_specification.jl
+++ b/src/structure_specification.jl
@@ -1,4 +1,110 @@
 """
+    NeuralLyapunovStructure(V, V̇, network_dim)
+
+Specifies the structure of the neural Lyapunov function and its derivative.
+
+Allows the user to define the Lyapunov in terms of the neural network, potentially
+structurally enforcing some Lyapunov conditions.
+
+# Fields
+  - `V(phi, state, fixed_point)`: outputs the value of the Lyapunov function at `state`.
+  - `V̇(phi, J_phi, state, d_state_dt, fixed_point)`: outputs the time derivative of the
+    Lyapunov function at `state`.
+  - `network_dim`: the dimension of the output of the neural network.
+
+`phi` and `J_phi` above are both functions of `state` alone.
+"""
+struct NeuralLyapunovStructure{TV, TDV, D <: Integer} <: AbstractNeuralLyapunovStructure{false}
+    V::TV
+    V̇::TDV
+    network_dim::D
+end
+
+function Base.show(io::IO, s::NeuralLyapunovStructure)
+    n = s.network_dim
+    if n > 1
+        @variables φ(..)[1:n] Jφ(..)[1:n, 1:1] x dxdt x_0 p t
+        println(io, "NeuralLyapunovStructure")
+        println(io, "    Network dimension: ", n)
+        try
+            V = string(s.V(φ, x, x_0))
+            # Regex to simplify broadcasting notation for better readability
+            # Replace, e.g., [1:1] with [1]
+            V = replace(V, r"\b(\d+):\1\b" => s"\1")
+            # Replace LinearAlgebra.dot(A, A) with ||A||^2 for better readability
+            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?1)\))*)\s*\)"
+            V = replace(V, dot_re => s"||\1||²")
+            # Replace abs2(A) with ||A||^2 for better readability
+            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace LinearAlgebra.dot with ⋅ for better readability
+            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
+            V = replace(V, dot_re => s"(\1)⋅(\2)")
+            # Replace ^2 with ²
+            V = replace(V, r"\^2" => "²")
+            println(io, "    V(x) = ", V)
+        catch e
+            println(io, "    V(x) = <could not display: $e>")
+        end
+        try
+            V̇ = string(s.V̇(φ, Jφ, x, dxdt, x_0))
+            # Regex to simplify broadcasting notation for better readability
+            # Replace, e.g., [1:2, Colon()] with [1:2]
+            V̇ = replace(V̇, r",\s*Colon\(\)" => "")
+            # Replace, e.g., [1:1] with [1]
+            V̇ = replace(V̇, r"\b(\d+):\1\b" => s"\1")
+            # Replace abs2(A) with ||A||^2 for better readability
+            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace LinearAlgebra.dot with ⋅ for better readability
+            dot_re = r"LinearAlgebra\.dot\(\s*((?:[^()]+|\((?1)\))*)\s*,\s*((?:[^()]+|\((?2)\))*)\s*\)"
+            V̇ = replace(V̇, dot_re => s"(\1)⋅(\2)")
+            # Replace ^2 with ²
+            V̇ = replace(V̇, r"\^2" => "²")
+            # Replace Differential(x, 1)(φ(x)) with Jφ(x) for better readability
+            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "Jφ(x)")
+            # Replace dxdt with ẋ for better readability
+            V̇ = replace(V̇, r"dxdt" => "ẋ")
+            println(io, "    V̇(x) = ", V̇)
+        catch e
+            println(io, "    V̇(x) = <could not display: $(e)>")
+        end
+    else
+        @variables φ(..) ∇φ(..) x dxdt x_0 p t
+        println(io, "NeuralLyapunovStructure")
+        println(io, "    Network dimension: ", n)
+        try
+            V = string(s.V(φ, x, x_0))
+            # Replace abs2(A) with ||A||² for better readability
+            V = replace(V, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace ^2 with ²
+            V = replace(V, r"\^2" => "²")
+            println(io, "    V(x) = ", V)
+        catch e
+            println(io, "    V(x) = <could not display: $(e)>")
+        end
+        try
+            V̇ = string(s.V̇(φ, ∇φ, x, dxdt, x_0))
+            # Replace abs2(A) with ||A||^2 for better readability
+            V̇ = replace(V̇, r"abs2\(\s*((?:[^()]+|\((?1)\))*)\s*\)" => s"||\1||²")
+            # Replace ^2 with ²
+            V̇ = replace(V̇, r"\^2" => "²")
+            # Replace Differential(x, 1)(φ(x)) with ∇φ(x) for better readability
+            V̇ = replace(V̇, r"Differential\(x, 1\)\(φ\(x\)\)" => "∇φ(x)")
+            # Replace dxdt with ẋ for better readability
+            V̇ = replace(V̇, r"dxdt" => "ẋ")
+            println(io, "    V̇(x) = ", V̇)
+        catch e
+            println(io, "    V̇(x) = <could not display: $(e)>")
+        end
+    end
+    return
+end
+
+get_V(spec::NeuralLyapunovStructure) = spec.V
+get_V̇(spec::NeuralLyapunovStructure) = spec.V̇
+get_network_dim(spec::NeuralLyapunovStructure) = spec.network_dim
+neural_controller(::NeuralLyapunovStructure) = false
+
+"""
     NoAdditionalStructure()
 
 Create a [`NeuralLyapunovStructure`](@ref) where the Lyapunov function is the neural network
@@ -11,20 +117,18 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest; filter = [r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"φ\\(x\\)" => "φ", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(∇φ\\s*\\*\\s*ẋ|ẋ\\s*\\*\\s*∇φ)\$"]
+```jldoctest; filter = [r"ẋ" => "ẋ", r"φ\\(x\\)" => "φ", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(∇φ\\s*\\*\\s*ẋ|ẋ\\s*\\*\\s*∇φ)\$"]
 julia> NoAdditionalStructure()
 NeuralLyapunovStructure
     Network dimension: 1
     V(x) = φ(x)
-    V̇(x) = ∇φ(x)*f(x, p, t)
-    f_call(x) = f(x, p, t)
+    V̇(x) = ∇φ(x)*ẋ
 ```
 """
 function NoAdditionalStructure()::NeuralLyapunovStructure
     return NeuralLyapunovStructure(
         (net, x, x0) -> net(x),
-        (net, grad_net, f, x, p, t, x0) -> grad_net(x) ⋅ f(x, p, t),
-        (f, net, x, p, t) -> f(x, p, t),
+        (net, grad_net, x, ẋ, x0) -> grad_net(x) ⋅ ẋ,
         1
     )
 end
@@ -62,13 +166,12 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest; filter = [r"\\(?x - x_0\\)?" => "Δ", r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"\\s*\\*\\s*" => "", r"φ\\(x\\)|\\(φ\\(x\\)\\)" => "φ", r"\\|\\|φ\\|\\|²" => "φ²", r"0.1\\s*log\\((1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)" => "A", r"(?m)\\s*V\\(x\\)\\s*=\\s*(A\\s*\\+\\s*φ²|φ²\\s*\\+\\s*A)\$", r"(ẋJφ|Jφẋ|\\(ẋJφ\\)|\\(Jφẋ\\))" => "φ̇", r"2(φ⋅φ̇|φ̇⋅φ)" => "B", r"\\(?(1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)?"=> "C", r"\\(?0.2(Δẋ|ẋΔ)\\)?" => "D", r"D\\s*/\\s*C" => "E", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(B\\s*\\+\\s*E|E\\s*\\+\\s*B)\$"]
+```jldoctest; filter = [r"\\(?x - x_0\\)?" => "Δ", r"ẋ" => "ẋ", r"\\s*\\*\\s*" => "", r"φ\\(x\\)|\\(φ\\(x\\)\\)" => "φ", r"\\|\\|φ\\|\\|²" => "φ²", r"0.1\\s*log\\((1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)" => "A", r"(?m)\\s*V\\(x\\)\\s*=\\s*(A\\s*\\+\\s*φ²|φ²\\s*\\+\\s*A)\$", r"(ẋJφ|Jφẋ|\\(ẋJφ\\)|\\(Jφẋ\\))" => "φ̇", r"2(φ⋅φ̇|φ̇⋅φ)" => "B", r"\\(?(1\\s*\\+\\s*Δ²|Δ²\\s*\\+\\s*1)\\)?"=> "C", r"\\(?0.2(Δẋ|ẋΔ)\\)?" => "D", r"D\\s*/\\s*C" => "E", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(B\\s*\\+\\s*E|E\\s*\\+\\s*B)\$"]
 julia> NonnegativeStructure(3; δ = 0.1)
 NeuralLyapunovStructure
     Network dimension: 3
     V(x) = 0.1log(1 + (x - x_0)²) + ||φ(x)||²
-    V̇(x) = 2(φ(x))⋅(f(x, p, t)*Jφ(x)) + (0.2(x - x_0)*f(x, p, t)) / (1 + (x - x_0)²)
-    f_call(x) = f(x, p, t)
+    V̇(x) = 2(φ(x))⋅(ẋ*Jφ(x)) + (0.2(x - x_0)*ẋ) / (1 + (x - x_0)²)
 ```
 
 See also: [`DontCheckNonnegativity`](@ref)
@@ -83,8 +186,7 @@ function NonnegativeStructure(
     return if δ == 0
         NeuralLyapunovStructure(
             (net, x, x0) -> net(x) ⋅ net(x),
-            (net, J_net, f, x, p, t, x0) -> 2 * dot(net(x), J_net(x), f(x, p, t)),
-            (f, net, x, p, t) -> f(x, p, t),
+            (net, J_net, x, ẋ, x0) -> 2 * dot(net(x), J_net(x), ẋ),
             network_dim
         )
     else
@@ -100,10 +202,9 @@ function NonnegativeStructure(
         end
         NeuralLyapunovStructure(
             (net, x, x0) -> net(x) ⋅ net(x) + δ * pos_def(x, x0),
-            function (net, J_net, f, x, p, t, x0)
-                return 2 * dot(net(x), J_net(x), f(x, p, t)) + δ * grad_pos_def(x, x0) ⋅ f(x, p, t)
+            function (net, J_net, x, ẋ, x0)
+                return 2 * dot(net(x), J_net(x), ẋ) + δ * grad_pos_def(x, x0) ⋅ ẋ
             end,
-            (f, net, x, p, t) -> f(x, p, t),
             network_dim
         )
     end
@@ -149,13 +250,12 @@ Dynamics are assumed to be in `f(state, p, t)` form, as in an `ODEFunction`. For
 `f(state, input, p, t)`, consider using [`add_policy_search`](@ref).
 
 # Example
-```jldoctest; filter = [r"\\(?2x - 2x_0\\)?" => "2(x - x_0)", r"\\(?x - x_0\\)?" => "Δ", r"\\|\\|Δ\\|\\|²" => "Δ²", r"φ\\(x\\)" => "φ", r"\\(?1\\s*\\+\\s*φ²\\)?" => "Y", r"\\s*\\*\\s*" => "", r"(?m)\\s*V\\(x\\)\\s*=\\s*(?:Δ²Y|YΔ²)\$", r"f\\(\\s*x,\\s*p,\\s*t\\s*\\)" => "ẋ", r"(2ΔẋY|2ΔYẋ|ẋ2ΔY|ẋY2Δ|Yẋ2Δ|Y2Δẋ)" => "A", r"(2|∇φ|ẋ|Δ²|φ){5}" => "B", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(A|B)\\s*\\+\\s*(A|B)\$"]
+```jldoctest; filter = [r"\\(?2x - 2x_0\\)?" => "2(x - x_0)", r"\\(?x - x_0\\)?" => "Δ", r"\\|\\|Δ\\|\\|²" => "Δ²", r"φ\\(x\\)" => "φ", r"\\(?1\\s*\\+\\s*φ²\\)?" => "Y", r"\\s*\\*\\s*" => "", r"(?m)\\s*V\\(x\\)\\s*=\\s*(?:Δ²Y|YΔ²)\$", r"ẋ" => "ẋ", r"(2ΔẋY|2ΔYẋ|ẋ2ΔY|ẋY2Δ|Yẋ2Δ|Y2Δẋ)" => "A", r"(2|∇φ|ẋ|Δ²|φ){5}" => "B", r"(?m)\\s*V̇\\(x\\)\\s*=\\s*(A|B)\\s*\\+\\s*(A|B)\$"]
 julia> PositiveSemiDefiniteStructure(1; pos_def = (x, x0) -> sum(abs2, x - x0))
 NeuralLyapunovStructure
     Network dimension: 1
     V(x) = (1 + φ(x)²)*||x - x_0||²
-    V̇(x) = (2x - 2x_0)*f(x, p, t)*(1 + φ(x)²) + 2∇φ(x)*f(x, p, t)*||x - x_0||²*φ(x)
-    f_call(x) = f(x, p, t)
+    V̇(x) = (2x - 2x_0)*ẋ*(1 + φ(x)²) + 2∇φ(x)*ẋ*||x - x_0||²*φ(x)
 ```
 
 See also: [`DontCheckNonnegativity`](@ref)
@@ -187,13 +287,11 @@ function PositiveSemiDefiniteStructure(
     end
     return NeuralLyapunovStructure(
         (net, x, x0) -> pos_def(x, x0) * non_neg(net, x, x0),
-        function (net, J_net, f, x, p, t, x0)
-            ẋ = f(x, p, t)
+        function (net, J_net, x, ẋ, x0)
             d_pos_def = ẋ ⋅ grad_pos_def(x, x0)
             d_non_neg = ẋ ⋅ grad_non_neg(net, J_net, x, x0)
             return d_pos_def * non_neg(net, x, x0) + pos_def(x, x0) * d_non_neg
         end,
-        (f, net, x, p, t) -> f(x, p, t),
         network_dim
     )
 end

--- a/test/Benchmarking/benchmark.jl
+++ b/test/Benchmarking/benchmark.jl
@@ -181,7 +181,6 @@ end
         optimization_args,
         state_syms,
         parameter_syms,
-        policy_search = true,
         endpoint_check,
         classifier,
         init_params = ps,

--- a/test/Policy_search/inverted_pendulum.jl
+++ b/test/Policy_search/inverted_pendulum.jl
@@ -80,7 +80,6 @@ spec = NeuralLyapunovSpecification(structure, minimization_condition, decrease_c
     p,
     state_syms,
     parameter_syms,
-    policy_search = true
 )
 
 ######################## Construct OptimizationProblem ########################

--- a/test/Unimplemented/unimplemented.jl
+++ b/test/Unimplemented/unimplemented.jl
@@ -16,3 +16,16 @@ cond = UnimplementedDecreaseCondition()
 
 @test_throws ErrorException NeuralLyapunov.check_decrease(cond)
 @test_throws ErrorException NeuralLyapunov.get_decrease_condition(cond)
+
+struct UnimplementedNeuralLyapunovStructure{nc} <: NeuralLyapunov.AbstractNeuralLyapunovStructure{nc} end
+
+str = UnimplementedNeuralLyapunovStructure{true}()
+@test_throws ErrorException NeuralLyapunov.get_control_structure(str)
+@test_throws ErrorException NeuralLyapunov.get_control_dim(str)
+@test_throws ErrorException NeuralLyapunov.get_V(str)
+@test_throws ErrorException NeuralLyapunov.get_V̇(str)
+@test_throws ErrorException NeuralLyapunov.get_network_dim(str)
+
+str = UnimplementedNeuralLyapunovStructure{false}()
+@test_throws ErrorException NeuralLyapunov.get_control_structure(str)
+@test_throws ErrorException NeuralLyapunov.get_control_dim(str)


### PR DESCRIPTION
* Remove `f_call` from `NeuralLyapunovStructure`

* New `AbstractNeuralLyapunovStructure` type supertypes it and new `NeuralLyapunovControlStructure` type

* Allow `control_structure` input to `add_policy_search` to depend on `state` and `fixed_point` as well as the network output.

## Checklist

- [x] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Simplifies handling of dynamics because now users must always have `f(x, p, t)` or `f(x, u, p, t)` instead of being able to have some strange other dynamics call via `f_call`. More predictable dynamics handling should aid in future work.