### PR TITLE
Stabilize Benchmarking policy-search accuracy test on Julia pre

### DIFF
--- a/test/Benchmarking/benchmark.jl
+++ b/test/Benchmarking/benchmark.jl
@@ -382,8 +382,13 @@ end
     )
 
     # Define optimization parameters
-    opt = Adam(0.05)
-    optimization_args = [:maxiters => 300]
+    # A low-learning-rate refinement phase follows the initial Adam(0.05) phase so
+    # the policy converges to a deeper, more reproducible minimum. A single short
+    # Adam(0.05) phase leaves the classifier accuracy hovering just around the 0.9
+    # acceptance threshold, which floating-point non-determinism across Julia
+    # versions can tip below it; the refinement phase restores a comfortable margin.
+    opt = [Adam(0.05), Adam(0.001)]
+    optimization_args = [[:maxiters => 300], [:maxiters => 300]]
 
     # Run benchmark
     endpoint_check = (x) -> ≈([sin(x[1]), cos(x[1]), x[2]], [0, -1, 0], atol = 5.0e-3)


### PR DESCRIPTION
## Fix flaky Benchmarking accuracy assertion on Julia `pre` (1.13.0-rc1)

The `tests / Benchmarking (julia pre)` job on `master` was failing at
`test/Benchmarking/benchmark.jl:412`:

```
Policy search on inverted pendulum (ODESystem) benchmarking: Test Failed
  Expression: (cm.Count[1] + cm.Count[3]) / sum(cm.Count) > 0.9
   Evaluated: 0.78 > 0.9
```

### Root cause

This `> 0.9` assertion checks the classification accuracy of a neural-network
policy trained by stochastic optimization. The training used a single short
`Adam(0.05)` phase of only 300 iterations, leaving the converged accuracy
sitting *just around* the 0.9 acceptance threshold. On the stable Julia
channels (`lts`, `1`) it lands above 0.9, but on the `pre` channel
(`1.13.0-rc1`) the different floating-point / BLAS arithmetic perturbs the
gradient trajectory enough to tip the result below the threshold.

This is genuine run-to-run / cross-version non-determinism of the optimizer,
not a regression in the package logic. Evidence (identical source, `pre` only):

| commit / run | line 195 | line 412 |
|---|---|---|
| `6826237` | 0.805 (fail) | 0.875 (fail) |
| `4b5f8912` (HEAD) | pass | 0.78 (fail) |
| local repro (1.13.0-rc1) | — | 0.505 (fail) |

Both the value and *which* assertion fails vary across runs of unchanged code.

### Fix

Give the ODESystem policy-search benchmark the same two-phase optimizer
schedule that the (more robust) first policy-search benchmark already uses — an
`Adam(0.05)` exploration phase followed by an `Adam(0.001)` refinement phase:

```julia
opt = [Adam(0.05), Adam(0.001)]
optimization_args = [[:maxiters => 300], [:maxiters => 300]]
```

The refinement phase drives the policy to a deeper, more reproducible minimum so
the classifier accuracy clears 0.9 with comfortable margin on all Julia
channels. **No assertion was weakened, skipped, or loosened** — the `> 0.9`
threshold is unchanged; only the training that feeds it was made more robust.

### Local verification

Run on `julia 1.13.0-rc1` (the failing `pre` channel) with the same resolved
dependency versions CI uses (ModelingToolkit 11.28.0, NeuralPDE 6.0.0,
Lux 1.31.4, SciMLBase 3.21.0):

- Baseline (current `master` schedule): accuracy = **0.505**, counts `[101, 99, 0, 0]` (FAIL) —
  reproduces the failure (even worse than CI's 0.78, confirming the high run-to-run variance).
- This PR's two-phase schedule: accuracy = **1.0**, counts `[200, 0, 0, 0]` (PASS, all 200
  evaluation points correctly classified — comfortable margin above the 0.9 threshold).

Please ignore until reviewed by @ChrisRackauckas.
