### PR TITLE
Bump version to 0.4.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunov"
 uuid = "61252e1c-87f0-426a-93a7-3cdb1ed5a867"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com>"]
 
 [deps]


### PR DESCRIPTION
Automated patch version bump (0.4.4 -> 0.4.5) to release unreleased commits on `master` via JuliaRegistrator.