### PR TITLE
Release prep: batched version bumps for 2 packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunov"
 uuid = "61252e1c-87f0-426a-93a7-3cdb1ed5a867"
-version = "0.4.5"
+version = "0.4.6"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com>"]
 
 [deps]

--- a/lib/NeuralLyapunovProblemLibrary/Project.toml
+++ b/lib/NeuralLyapunovProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunovProblemLibrary"
 uuid = "83723521-ca9c-4edc-8e64-505178d150fe"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
## Summary

Batched release-prep PR for the monorepo. Both packages have accumulated only QA/test-scaffolding and dependency compat-floor changes since their last registered versions (verified via file diff scoped to each package's own paths against its last release commit; no `src/` changes in either).

### Packages released

| Package | Old | New | Bump | Reason |
|---|---|---|---|---|
| `NeuralLyapunov` (root) | 0.4.5 | 0.4.6 | patch | Own changes only: CI/TagBot workflow update (monorepo-aware tagbot), QA test harness updates (`run_qa` v1.6 form, `ExplicitImports`), and a `SciMLTesting` compat floor raise (`1` -> `2.1`). No `src/` changes. |
| `NeuralLyapunovProblemLibrary` (`lib/NeuralLyapunovProblemLibrary`) | 0.2.4 | 0.2.5 | patch | Own changes only: QA test harness migrated to `run_qa`/`SciMLTesting` (dropped separate `Aqua`/`ExplicitImports` test files), and a `SciMLTesting` compat floor raise (`1` -> `2.1`). No `src/` changes. |

### Compat-floor cascade check

- Root does not runtime-depend on `NeuralLyapunovProblemLibrary` (it only appears in root's `[extras]`/`[sources]`/test target, not `[deps]`), so no cascade obligation there regardless.
- Neither package's changes add new public API/behavior (QA/test scaffolding + compat floor only), so no sibling package needs its floor raised as a result of this release.
- No further packages in the monorepo needed to be pulled into this release.

### Note (not addressed in this PR, flagging for visibility)

Root's `[compat]` floor on `NeuralLyapunovProblemLibrary` is currently `"0.2.3"`, which is already below the previously-released `0.2.4` (i.e. stale prior to this PR, not something this PR's changes caused). Left untouched per scope — flagging separately since fixing it requires confirming whether root's test code actually needs something introduced in 0.2.4, which is outside the context of this batched bump.

## Test plan

- [ ] CI matrix passes on this PR (existing test suites for both packages, unchanged besides QA harness/compat floor)