### PR TITLE
Sync package versions with the General registry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunov"
 uuid = "61252e1c-87f0-426a-93a7-3cdb1ed5a867"
-version = "0.4.6"
+version = "0.4.7"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com>"]
 
 [deps]

--- a/lib/NeuralLyapunovProblemLibrary/Project.toml
+++ b/lib/NeuralLyapunovProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunovProblemLibrary"
 uuid = "83723521-ca9c-4edc-8e64-505178d150fe"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

## What this changes

| package | from | to | why |
|---|---|---|---|
| `NeuralLyapunov` | 0.4.6 | 0.4.7 | unreleased changes with no version bump |
| `NeuralLyapunovProblemLibrary` | 0.2.5 | 0.2.6 | unreleased changes with no version bump |


## Why

Each `to` is the next sequential version after what is currently registered in
General. Versions that skip an unregistered version are rejected by AutoMerge's
sequential version number guideline, so they can never be registered as-is;
packages with unreleased changes and no bump cannot be registered at all.

Only the top-level `version` field of each `Project.toml` is touched.

After merge, each package still needs `@JuliaRegistrator register` (with
`subdir=` where applicable).