### PR TITLE
Import SciMLBase directly in NeuralPDE test

### DIFF
--- a/test/Core/damped_sho.jl
+++ b/test/Core/damped_sho.jl
@@ -1,4 +1,4 @@
-using NeuralPDE, Lux, NeuralLyapunov, ComponentArrays
+using NeuralPDE, SciMLBase, Lux, NeuralLyapunov, ComponentArrays
 using Boltz.Layers: MLP
 import Optimization
 using OptimizationOptimisers: Adam


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary
- import `SciMLBase` from its owning package in the damped SHO test
- stop relying on NeuralPDE blanket-reexporting dependency APIs
- unblock the NeuralPDE strict reexport QA migration in SciML/NeuralPDE.jl#1106

## Local verification
- `GROUP=Core julia +release --project=. -e "using Pkg; Pkg.test(; coverage=false)"`
- `GROUP=Core julia +1.10 --project=. -e "using Pkg; Pkg.test(; coverage=false)"`
- Runic `--check .` on Julia release and 1.10