### PR TITLE
Import `@named` from ModelingToolkitBase

### DIFF
--- a/test/Core/damped_sho.jl
+++ b/test/Core/damped_sho.jl
@@ -1,4 +1,5 @@
 using NeuralPDE, SciMLBase, Lux, NeuralLyapunov, ComponentArrays
+using ModelingToolkitBase: @named
 using Boltz.Layers: MLP
 import Optimization
 using OptimizationOptimisers: Adam


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

Import `@named` directly from its declaring public owner, ModelingToolkitBase, in the damped oscillator test.

This is the small downstream prerequisite for NeuralPDE #1106 after NeuralPDE stops forwarding dependency-owned exports. It changes no package behavior.

## Verification

- Julia 1.12.6: full `Pkg.test()`, 34 passed
- Julia 1.10.11: full `Pkg.test()`, 34 passed
- Runic check: all 46 tracked Julia files passed
- `git diff --check`: passed