### PR TITLE
docs: specify NeuralLyapunov extension interfaces

### DIFF
--- a/docs/src/man/internals.md
+++ b/docs/src/man/internals.md
@@ -1,6 +1,14 @@
-# Internals
+# Developer API
+
+This page documents the developer-facing extension points used by
+`NeuralLyapunovPDESystem`. These interfaces are version-controlled and tested for
+compatibility with the generic package code, but they are intended for packages that build
+new NeuralLyapunov formulations rather than for ordinary application code. Implement a
+subtype and extend the documented generic functions; do not depend on fields of the built-in
+concrete types or on names omitted from this page.
 
 ```@docs
+NeuralLyapunov.NeuralLyapunov
 NeuralLyapunov.phi_to_net
 NeuralLyapunov.NeuralLyapunovBenchmarkLogger
 NeuralLyapunov.AbstractNeuralLyapunovStructure

--- a/src/NeuralLyapunov.jl
+++ b/src/NeuralLyapunov.jl
@@ -1,3 +1,14 @@
+"""
+    NeuralLyapunov
+
+Build and train neural Lyapunov-function formulations for dynamical systems.
+
+The package exposes composable structures for the candidate Lyapunov function, its
+minimization condition, and its decrease condition. These components are assembled into
+symbolic `ModelingToolkitBase.PDESystem`s for use with NeuralPDE. The abstract types and
+generic functions documented on the developer API page are extension points for packages
+that provide additional formulations.
+"""
 module NeuralLyapunov
 
 import DifferentiationInterface

--- a/src/conditions_specification.jl
+++ b/src/conditions_specification.jl
@@ -1,31 +1,99 @@
 """
     AbstractNeuralLyapunovStructure{nc}
 
-Represents the structure of the neural Lyapunov function and its derivative.
+Developer interface for a neural Lyapunov-function structure.
 
-All concrete `AbstractNeuralLyapunovStructure` subtypes should define the `get_V`, `get_V̇`,
-and `get_network_dim` functions. If `nc` is `true`, the subtype should also define the
-`get_control_structure` and `get_control_dim` functions.
+The type parameter `nc` records whether the structure includes a neural-network-dependent
+control or other contribution to the dynamics. A subtype must implement the following
+generic functions for every instance:
+
+  - [`get_V`](@ref): return `V(phi, state, fixed_point)`, where `phi` is a callable neural
+    network and `state` is a single state vector.
+  - [`get_V̇`](@ref): return `V̇(phi, J_phi, state, dstate_dt, fixed_point)`, where `J_phi`
+    evaluates the derivative of `phi` with respect to `state`.
+  - [`get_network_dim`](@ref): return the positive number of neural-network outputs used by
+    the structure.
+
+For a subtype of `AbstractNeuralLyapunovStructure{true}`, also implement
+[`get_control_structure`](@ref), returning `control_structure(phi_c, state, fixed_point)`,
+and [`get_control_dim`](@ref), returning the positive number of outputs consumed by that
+structure. `phi` and `J_phi` must be functions of `state` alone; implementations must not
+assume a particular concrete structure type or access its fields from generic code.
+
+The `false` and `true` parameter values are part of the dispatch contract. Use
+`AbstractNeuralLyapunovStructure{false}` for dynamics of the form `f(state, p, t)` and
+`AbstractNeuralLyapunovStructure{true}` for dynamics of the form `f(state, control, p, t)`.
+
+# Example
+
+```julia
+struct MyStructure <: AbstractNeuralLyapunovStructure{false} end
+
+NeuralLyapunov.get_V(::MyStructure) = (phi, state, fixed_point) -> phi(state)[1]
+NeuralLyapunov.get_V̇(::MyStructure) =
+    (phi, J_phi, state, dstate_dt, fixed_point) -> sum(J_phi(state)[1, :] .* dstate_dt)
+NeuralLyapunov.get_network_dim(::MyStructure) = 1
+```
 """
 abstract type AbstractNeuralLyapunovStructure{nc} end
 
 """
     AbstractLyapunovMinimizationCondition
 
-Represents the minimization condition in a neural Lyapunov problem
+Developer interface for the minimization condition in a neural Lyapunov problem.
 
-All concrete `AbstractLyapunovMinimizationCondition` subtypes should define the
-`check_nonnegativity`, `check_fixed_point`, and `get_minimization_condition` functions.
+A subtype must implement [`check_nonnegativity`](@ref),
+[`check_minimal_fixed_point`](@ref), and [`get_minimization_condition`](@ref). The first two
+generic functions return `Bool`s. If `check_nonnegativity(cond)` is `true`,
+`get_minimization_condition(cond)` must return a callable
+`(V, state, fixed_point) -> residual`, where `V` is callable as `V(state)` and `residual`
+is a scalar or a vector whose entries are all zero when the condition is satisfied. If the
+flag is `false`, the returned condition may be `nothing`, because no minimization equation
+is generated. The `check_minimal_fixed_point` flag independently controls whether
+`V(fixed_point) = 0` is added by [`NeuralLyapunovPDESystem`](@ref).
+
+Implementations should extend these generic functions for their own subtype and should not
+depend on the fields of another package's concrete condition.
+
+# Example
+
+```julia
+struct MyMinimizationCondition <: AbstractLyapunovMinimizationCondition end
+
+NeuralLyapunov.check_nonnegativity(::MyMinimizationCondition) = true
+NeuralLyapunov.check_minimal_fixed_point(::MyMinimizationCondition) = true
+NeuralLyapunov.get_minimization_condition(::MyMinimizationCondition) =
+    (V, state, fixed_point) -> V(state) - V(fixed_point)
+```
 """
 abstract type AbstractLyapunovMinimizationCondition end
 
 """
     AbstractLyapunovDecreaseCondition
 
-Represents the decrease condition in a neural Lyapunov problem
+Developer interface for the decrease condition in a neural Lyapunov problem.
 
-All concrete `AbstractLyapunovDecreaseCondition` subtypes should define the
-`check_decrease` and `get_decrease_condition` functions.
+A subtype must implement [`check_decrease`](@ref) and [`get_decrease_condition`](@ref).
+`check_decrease(cond)` returns a `Bool`. If it is `true`,
+`get_decrease_condition(cond)` must return a callable
+`(V, V̇, state, fixed_point) -> residual`, where `V` and `V̇` are callable at `state` and the
+residual is a scalar or vector that is zero when the condition is satisfied. If the flag is
+`false`, the returned condition may be `nothing`, because no decrease equation is generated.
+The implementation may evaluate `V` and `V̇` at additional points, but it must preserve this
+call signature so that it works with the generic PDESystem construction.
+
+Implementations should extend these generic functions for their own subtype and should not
+depend on the fields of another package's concrete condition.
+
+# Example
+
+```julia
+struct MyDecreaseCondition <: AbstractLyapunovDecreaseCondition end
+
+NeuralLyapunov.check_decrease(::MyDecreaseCondition) = true
+NeuralLyapunov.get_decrease_condition(::MyDecreaseCondition) =
+    (V, V̇, state, fixed_point) -> V̇(state)
+```
 """
 abstract type AbstractLyapunovDecreaseCondition end
 
@@ -85,6 +153,20 @@ end
 
 Return a function `V(phi, state, fixed_point)` that outputs the value of the Lyapunov
 function at `state`.
+
+# Arguments
+
+- `str`: the neural Lyapunov structure being queried.
+
+# Returns
+
+A callable accepting a neural network `phi`, a state vector, and a fixed point. It may
+return a scalar or an array compatible with the condition and PDESystem constructors.
+
+# Extension Rules
+
+Define a method for each concrete subtype. The returned callable must not rely on a
+specific neural-network implementation.
 """
 function get_V(str::AbstractNeuralLyapunovStructure)
     error(
@@ -98,6 +180,21 @@ end
 
 Return a function `V̇(phi, J_phi, state, dstate_dt, fixed_point)` that outputs the
 time derivative of the Lyapunov function at `state`.
+
+# Arguments
+
+- `str`: the neural Lyapunov structure being queried.
+
+# Returns
+
+A callable accepting the neural network `phi`, its state Jacobian `J_phi`, a state vector,
+the state derivative `dstate_dt`, and a fixed point. It may return a scalar or an array
+compatible with the generated equations.
+
+# Extension Rules
+
+Define a method for each concrete subtype. `J_phi` must be treated as a callable of the
+state, rather than as a package-specific differentiation object.
 """
 function get_V̇(str::AbstractNeuralLyapunovStructure)
     error(
@@ -109,7 +206,16 @@ end
 """
     get_network_dim(str::AbstractNeuralLyapunovStructure)
 
-Return the number of dimensions of the neural network output specified by `spec`.
+Return the number of dimensions of the neural network output specified by `str`.
+
+# Arguments
+
+- `str`: the neural Lyapunov structure being queried.
+
+# Returns
+
+A positive `Integer` equal to the number of neural-network outputs consumed by `get_V` and
+`get_V̇`.
 """
 function get_network_dim(str::AbstractNeuralLyapunovStructure)
     error(
@@ -121,7 +227,22 @@ end
 """
     get_control_structure(str::AbstractNeuralLyapunovStructure{true})
 
-Return the control structure specified by `spec`.
+Return the control structure specified by `str`.
+
+# Arguments
+
+- `str`: an `AbstractNeuralLyapunovStructure{true}` instance.
+
+# Returns
+
+A callable `control_structure(phi_c, state, fixed_point)` that transforms the control-output
+portion of the neural network into the input expected by the dynamics.
+
+# Extension Rules
+
+This method is required only for `AbstractNeuralLyapunovStructure{true}`. It must preserve
+the callable signature so that [`add_policy_search`](@ref) and [`get_policy`](@ref) can use
+the result without knowing the concrete subtype.
 """
 function get_control_structure(str::AbstractNeuralLyapunovStructure{nc}) where {nc}
     return if nc
@@ -137,7 +258,16 @@ end
 """
     get_control_dim(str::AbstractNeuralLyapunovStructure{true})
 
-Return the control dimension specified by `spec`.
+Return the control dimension specified by `str`.
+
+# Arguments
+
+- `str`: an `AbstractNeuralLyapunovStructure{true}` instance.
+
+# Returns
+
+A positive `Integer` equal to the number of neural-network outputs passed through
+`get_control_structure`.
 """
 function get_control_dim(str::AbstractNeuralLyapunovStructure{nc}) where {nc}
     return if nc
@@ -155,6 +285,15 @@ end
 
 Return `true` if `str` specifies a neural controller (i.e., if `str` is a subtype of
 `AbstractNeuralLyapunovStructure{true}`) and `false` otherwise.
+
+# Arguments
+
+- `str`: the neural Lyapunov structure to classify.
+
+# Returns
+
+`true` exactly for structures parameterized as `AbstractNeuralLyapunovStructure{true}` and
+`false` for structures parameterized as `AbstractNeuralLyapunovStructure{false}`.
 """
 neural_controller(::AbstractNeuralLyapunovStructure{nc}) where {nc} = nc
 
@@ -163,6 +302,15 @@ neural_controller(::AbstractNeuralLyapunovStructure{nc}) where {nc} = nc
 
 Return `true` if `cond` specifies training to meet the Lyapunov minimization condition, and
 `false` if `cond` specifies no training to meet this condition.
+
+# Arguments
+
+- `cond`: the minimization condition being queried.
+
+# Returns
+
+A `Bool`. When `true`, the generic PDESystem construction consumes the residual returned by
+[`get_minimization_condition`](@ref).
 """
 function check_nonnegativity(cond::AbstractLyapunovMinimizationCondition)::Bool
     error(
@@ -176,6 +324,15 @@ end
 
 Return `true` if `cond` specifies training for the Lyapunov function to equal zero at the
 fixed point, and `false` if `cond` specifies no training to meet this condition.
+
+# Arguments
+
+- `cond`: the minimization condition being queried.
+
+# Returns
+
+A `Bool` controlling whether the generic PDESystem construction adds the equation
+`V(fixed_point) = 0`.
 """
 function check_minimal_fixed_point(cond::AbstractLyapunovMinimizationCondition)::Bool
     error(
@@ -197,6 +354,15 @@ the value of the candidate Lyapunov function at multiple points.
 If the returned function returns a vector, all elements of the vector must be zero for the
 condition to be considered met.
 [`NeuralLyapunovPDESystem`](@ref) will create one equation per element of the vector.
+
+# Arguments
+
+- `cond`: the minimization condition being queried.
+
+# Returns
+
+Either `nothing` when no nonnegativity equation is requested, or a callable
+`(V, state, fixed_point) -> residual` returning a scalar or vector residual.
 """
 function get_minimization_condition(cond::AbstractLyapunovMinimizationCondition)
     error(
@@ -228,6 +394,15 @@ end
 
 Return `true` if `cond` specifies training to meet the Lyapunov decrease condition, and
 `false` if `cond` specifies no training to meet this condition.
+
+# Arguments
+
+- `cond`: the decrease condition being queried.
+
+# Returns
+
+A `Bool`. When `true`, the generic PDESystem construction consumes the residual returned by
+[`get_decrease_condition`](@ref).
 """
 function check_decrease(cond::AbstractLyapunovDecreaseCondition)::Bool
     error(
@@ -248,6 +423,15 @@ can depend on the value of these functions at multiple points.
 If the returned function returns a vector, all elements of the vector must be zero for the
 condition to be considered met.
 [`NeuralLyapunovPDESystem`](@ref) will create one equation per element of the vector.
+
+# Arguments
+
+- `cond`: the decrease condition being queried.
+
+# Returns
+
+Either `nothing` when no decrease equation is requested, or a callable
+`(V, V̇, state, fixed_point) -> residual` returning a scalar or vector residual.
 """
 function get_decrease_condition(cond::AbstractLyapunovDecreaseCondition)
     error(

--- a/test/Interface/interfaces.jl
+++ b/test/Interface/interfaces.jl
@@ -1,0 +1,80 @@
+using NeuralLyapunov
+using LinearAlgebra: ⋅
+using Test
+
+struct GenericStructure <: NeuralLyapunov.AbstractNeuralLyapunovStructure{false}
+    network_dim::Int
+end
+
+NeuralLyapunov.get_V(::GenericStructure) = (phi, state, fixed_point) -> phi(state)[1]
+NeuralLyapunov.get_V̇(::GenericStructure) =
+    (phi, J_phi, state, dstate_dt, fixed_point) -> J_phi(state)[1, :] ⋅ dstate_dt
+NeuralLyapunov.get_network_dim(s::GenericStructure) = s.network_dim
+
+struct GenericControlStructure <: NeuralLyapunov.AbstractNeuralLyapunovStructure{true}
+    network_dim::Int
+    control_dim::Int
+end
+
+NeuralLyapunov.get_V(::GenericControlStructure) = (phi, state, fixed_point) -> phi(state)[1]
+NeuralLyapunov.get_V̇(::GenericControlStructure) =
+    (phi, J_phi, state, dstate_dt, fixed_point) -> J_phi(state)[1, :] ⋅ dstate_dt
+NeuralLyapunov.get_network_dim(s::GenericControlStructure) = s.network_dim
+NeuralLyapunov.get_control_dim(s::GenericControlStructure) = s.control_dim
+NeuralLyapunov.get_control_structure(::GenericControlStructure) =
+    (phi_c, state, fixed_point) -> phi_c(state)
+
+struct GenericMinimizationCondition <: NeuralLyapunov.AbstractLyapunovMinimizationCondition end
+
+NeuralLyapunov.check_nonnegativity(::GenericMinimizationCondition) = true
+NeuralLyapunov.check_minimal_fixed_point(::GenericMinimizationCondition) = true
+NeuralLyapunov.get_minimization_condition(::GenericMinimizationCondition) =
+    (V, state, fixed_point) -> V(state) - V(fixed_point)
+
+struct GenericDecreaseCondition <: NeuralLyapunov.AbstractLyapunovDecreaseCondition end
+
+NeuralLyapunov.check_decrease(::GenericDecreaseCondition) = true
+NeuralLyapunov.get_decrease_condition(::GenericDecreaseCondition) =
+    (V, V̇, state, fixed_point) -> V̇(state)
+
+@testset "Structure interface" begin
+    state = [2.0, 3.0]
+    fixed_point = zeros(2)
+    phi = x -> [x[1], x[2]^2]
+    J_phi = x -> [1.0 0.0; 0.0 2x[2]]
+
+    structure = GenericStructure(2)
+    @test NeuralLyapunov.get_V(structure)(phi, state, fixed_point) == 2.0
+    @test NeuralLyapunov.get_V̇(structure)(phi, J_phi, state, [4.0, 5.0], fixed_point) == 4.0
+    @test NeuralLyapunov.get_network_dim(structure) == 2
+    @test !NeuralLyapunov.neural_controller(structure)
+
+    control_structure = GenericControlStructure(3, 1)
+    @test NeuralLyapunov.get_network_dim(control_structure) == 3
+    @test NeuralLyapunov.get_control_dim(control_structure) == 1
+    @test NeuralLyapunov.get_control_structure(control_structure)(phi, state, fixed_point) ==
+        [2.0, 9.0]
+    @test NeuralLyapunov.neural_controller(control_structure)
+
+    augmented = NeuralLyapunov.add_policy_search(structure, 1)
+    @test NeuralLyapunov.neural_controller(augmented)
+    @test NeuralLyapunov.get_network_dim(augmented) == 3
+    @test NeuralLyapunov.get_control_dim(augmented) == 1
+end
+
+@testset "Condition interfaces" begin
+    V = x -> sum(abs2, x)
+    V̇ = x -> -sum(abs2, x)
+    state = [2.0, 3.0]
+    fixed_point = zeros(2)
+
+    minimization = GenericMinimizationCondition()
+    @test NeuralLyapunov.check_nonnegativity(minimization)
+    @test NeuralLyapunov.check_minimal_fixed_point(minimization)
+    @test NeuralLyapunov.get_minimization_condition(minimization)(V, state, fixed_point) ==
+        13.0
+
+    decrease = GenericDecreaseCondition()
+    @test NeuralLyapunov.check_decrease(decrease)
+    @test NeuralLyapunov.get_decrease_condition(decrease)(V, V̇, state, fixed_point) == -13.0
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,6 +20,11 @@ run_tests(;
         end
     end,
     groups = Dict(
+        "Interface" => function ()
+            return @time @safetestset "Generic interface contracts" begin
+                include(joinpath(@__DIR__, "Interface", "interfaces.jl"))
+            end
+        end,
         "Policy_search" => function ()
             @time @safetestset "Policy search - inverted pendulum" begin
                 include(joinpath(@__DIR__, "Policy_search", "inverted_pendulum.jl"))
@@ -76,7 +81,7 @@ run_tests(;
             end
         end,
     ),
-    all = ["Core", "Policy_search", "ROA", "Local_lyapunov", "Benchmarking", "Unimplemented"],
+    all = ["Core", "Interface", "Policy_search", "ROA", "Local_lyapunov", "Benchmarking", "Unimplemented"],
     sublib_env = "NEURALLYAPUNOV_TEST_GROUP",
     lib_dir = joinpath(dirname(@__DIR__), "lib"),
 )

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -7,6 +7,9 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
+[Interface]
+versions = ["lts", "1", "pre"]
+
 [Policy_search]
 versions = ["lts", "1", "pre"]
 


### PR DESCRIPTION
This draft should be ignored until reviewed by @ChrisRackauckas.

## What changed

- Added definition-site SciMLStyle documentation for the neural Lyapunov structure, minimization-condition, and decrease-condition developer interfaces.
- Specified required generic call signatures, flags, return shapes, dispatch rules, and extension boundaries, with implementation examples.
- Added a Developer API docs page entry and a module docstring; all exported names now have definition-site documentation.
- Added a generic Interface test group using external-style test subtypes and only the documented generic functions.
- Kept the existing SciMLTesting 2.4 lower bounds and plain `run_qa` configuration unchanged; no repository-specific public-doc QA override is present.

## Verification

- Fresh `origin/master` fetched and fast-forwarded to `7bef676` before branching.
- `GROUP=Interface julia --startup-file=no --project -e 'using Pkg; Pkg.test()'`: `Generic interface contracts | 16 | 16`.
- `GROUP=Core julia --startup-file=no --project -e 'using Pkg; Pkg.test()'`: all five Core cases passed, `34/34` total.
- `GROUP=QA julia --startup-file=no --project -e 'using Pkg; Pkg.test()'`: `Quality Assurance | 20 | 20`.
- `julia --project=docs docs/make.jl`: exit 0; doctests, cross-references, document checks, and HTML rendering passed.
- Runtime export audit: `export_count=28`, `missing_docs=Symbol[]`.
- Runic, typos, Julia parser checks, and `git diff --check` passed.

GPU and downstream workflows were not run locally.