### PR TITLE
Release 1 sub-library

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunov"
 uuid = "61252e1c-87f0-426a-93a7-3cdb1ed5a867"
-version = "0.4.7"
+version = "0.4.8"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com>"]
 
 [deps]
@@ -37,7 +37,7 @@ MLDataDevices = "1.17.9"
 MatrixEquations = "2.5.7"
 ModelingToolkit = "11.26.7"
 ModelingToolkitBase = "1.42.0"
-NeuralLyapunovProblemLibrary = "0.2.3"
+NeuralLyapunovProblemLibrary = "0.2.7"
 NeuralPDE = "6.2.0"
 Optimization = "5.5.1"
 OptimizationOptimisers = "0.3.21"

--- a/lib/NeuralLyapunovProblemLibrary/Project.toml
+++ b/lib/NeuralLyapunovProblemLibrary/Project.toml
@@ -1,6 +1,6 @@
 name = "NeuralLyapunovProblemLibrary"
 uuid = "83723521-ca9c-4edc-8e64-505178d150fe"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Nicholas Klugman <13633349+nicholaskl97@users.noreply.github.com> and contributors"]
 
 [deps]


### PR DESCRIPTION
Sub-libraries whose registered tree has drifted from `master` are bumped and released together.

- `NeuralLyapunovProblemLibrary` 0.2.6 -> 0.2.7 (patch)

- **root `NeuralLyapunov`** 0.4.7 -> 0.4.8

Inter-sub-library `[compat]` lower bounds are raised to the new versions in the same commit, so a resolved set never mixes a new sub-library with an older sibling it was not tested against. All bumps are patch/minor - no exported name is removed anywhere in this set, so nothing here is breaking and no retroactive cap is required.

For `0.x` sub-libraries the patch slot is used, since the minor is the breaking axis under Julia's SemVer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FEzNTLFutCmTEAZ3zBg5R