### PR TITLE
test: import names NeuralPDE no longer reexports

### DIFF
--- a/test/Benchmarking/benchmark.jl
+++ b/test/Benchmarking/benchmark.jl
@@ -1,5 +1,5 @@
-using NeuralPDE, NeuralLyapunov, Lux, NeuralLyapunovProblemLibrary
-using ModelingToolkit: unbound_inputs
+using NeuralPDE, SciMLBase, NeuralLyapunov, Lux, NeuralLyapunovProblemLibrary
+using ModelingToolkit: @named, @mtkcompile, mtkcompile, unbound_inputs, unknowns
 import Boltz.Layers: PeriodicEmbedding, MLP
 using OptimizationOptimisers: Adam
 using StableRNGs, Random

--- a/test/Policy_search/inverted_pendulum.jl
+++ b/test/Policy_search/inverted_pendulum.jl
@@ -1,4 +1,5 @@
-using NeuralPDE, Lux, NeuralLyapunov
+using NeuralPDE, SciMLBase, Lux, NeuralLyapunov
+using ModelingToolkitBase: @named
 using OrdinaryDiffEqTsit5: Tsit5
 import Boltz.Layers: PeriodicEmbedding, MLP
 import Optimization

--- a/test/Policy_search/inverted_pendulum_ODESystem.jl
+++ b/test/Policy_search/inverted_pendulum_ODESystem.jl
@@ -1,6 +1,7 @@
 using NeuralPDE, Lux, ModelingToolkit, NeuralLyapunov, NeuralLyapunovProblemLibrary
 using OrdinaryDiffEqTsit5: Tsit5
 using ModelingToolkit: unbound_inputs
+using SciMLBase: ODEInputFunction
 import Boltz.Layers: PeriodicEmbedding, MLP
 import Optimization
 using OptimizationOptimisers: Adam

--- a/test/ROA/roa_estimation.jl
+++ b/test/ROA/roa_estimation.jl
@@ -1,4 +1,5 @@
 using NeuralPDE, Lux, ComponentArrays, NeuralLyapunov
+using ModelingToolkitBase: @named
 import Optimization
 using OptimizationOptimisers: Adam
 using Boltz.Layers: MLP


### PR DESCRIPTION
## Problem

The `Policy_search`, `ROA`, and `Benchmarking` test groups fail at load time on all Julia versions ([run 32932860480](https://github.com/SciML/NeuralLyapunov.jl/actions/runs/32932860480)):

```
LoadError: UndefVarError: `@named` not defined in `Main.var"##Policy search - inverted pendulum#283"`
UndefVarError: `SciMLBase` not defined in `Main.var"##Benchmarking tool#287"`
LoadError: UndefVarError: `@mtkcompile` not defined in `Main.var"##Benchmarking tool#287"`
```

NeuralPDE v5 had `@reexport using SciMLBase, ModelingToolkit`, which is gone in v6. These test files used `@named`, `SciMLBase`, `ODEFunction`, `ODEProblem`, `solve`, `EnsembleSerial`, `@mtkcompile`, `mtkcompile`, and `unknowns` without importing them, relying on that reexport. `test/Core/damped_sho.jl` was already fixed this way in #211 and #214; this applies the same pattern to the remaining files.

## Changes

- `test/ROA/roa_estimation.jl`: `using ModelingToolkitBase: @named`
- `test/Policy_search/inverted_pendulum.jl`: add `SciMLBase` and `using ModelingToolkitBase: @named`
- `test/Policy_search/inverted_pendulum_ODESystem.jl`: `using SciMLBase: ODEInputFunction` (not exported by ModelingToolkit/ModelingToolkitBase; this file never ran in the failing run because the group aborted on the first file)
- `test/Benchmarking/benchmark.jl`: add `SciMLBase`, and import `@named`, `@mtkcompile`, `mtkcompile`, `unknowns` alongside the existing `unbound_inputs`

Test-only change; no source or version changes.

## Test plan

- [ ] `Policy_search` group (both files load and pass)
- [ ] `ROA` group
- [ ] `Benchmarking` group

Made with [Cursor](https://cursor.com)